### PR TITLE
RenderLayer now uses the world position of the camera

### DIFF
--- a/clove/components/utilities/maths/include/Clove/Maths/MathsHelpers.hpp
+++ b/clove/components/utilities/maths/include/Clove/Maths/MathsHelpers.hpp
@@ -57,6 +57,9 @@ namespace garlic::clove {
      */
     template<typename T>
     vec<3, T> screenToWorld(vec<2, T> const &screenPos, T distance, vec<2, T> const &screenSize, vec<3, T> const &forward, mat<4, 4, T> const &viewMatrix, mat<4, 4, T> const &projectionMatrix);
+
+    template<typename T>
+    vec<3, T> decomposeTranslation(mat<4, 4, T> const &matrix);
 }
 
 #include "MathsHelpers.inl"

--- a/clove/components/utilities/maths/include/Clove/Maths/MathsHelpers.inl
+++ b/clove/components/utilities/maths/include/Clove/Maths/MathsHelpers.inl
@@ -114,4 +114,9 @@ namespace garlic::clove {
 
         return vec<3, T>{ world.x, world.y, world.z };
     }
+
+    template<typename T>
+    vec<3, T> decomposeTranslation(mat<4, 4, T> const &matrix){
+        return { matrix[3] };
+    }
 }

--- a/clove/source/Layers/RenderLayer.cpp
+++ b/clove/source/Layers/RenderLayer.cpp
@@ -12,6 +12,7 @@
 
 #include <Clove/ECS/EntityManager.hpp>
 #include <Clove/Maths/Maths.hpp>
+#include <Clove/Maths/MathsHelpers.hpp>
 
 namespace garlic::clove {
     RenderLayer::RenderLayer(ForwardRenderer3D *renderer, EntityManager *entityManager)
@@ -33,7 +34,7 @@ namespace garlic::clove {
 
         //Transform and submit cameras
         entityManager->forEach([this, &activeCamera](Entity entity, TransformComponent const &transform, CameraComponent &camera) {
-            vec3f const position{ transform.position };
+            vec3f const position{ decomposeTranslation(transform.worldMatrix) };
 
             vec3f const camFront{ transform.getForward() };
             vec3f const camUp{ transform.getUp() };


### PR DESCRIPTION
## Summary
This means that when cameras are parented they will properly move with their parent.

## Changes
- Added a way to decompose the translation from a matrix
- Fixed a bug where a camera wouldn't move with it's parent
