### PR TITLE
Fix optional compile issue

### DIFF
--- a/clove/components/core/graphics/include/Clove/Graphics/Graphics.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Graphics.hpp
@@ -3,7 +3,6 @@
 #include "Clove/Graphics/GraphicsAPI.hpp"
 
 #include <any>
-#include <optional>
 #include <memory>
 
 namespace garlic::clove {

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanFactory.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanFactory.hpp
@@ -4,7 +4,6 @@
 #include "Clove/Graphics/Vulkan/DevicePointer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanTypes.hpp"
 
-#include <optional>
 #include <vulkan/vulkan.h>
 
 namespace garlic::clove {

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -1,10 +1,15 @@
+//There seems to be a bug with optional in msvc that stops it compiling. Having this header included here (above VulkanFactory) is a current work around.
+#include "Clove/Graphics/Vulkan/VulkanRenderPass.hpp"
+//
 #include "Clove/Graphics/Vulkan/VulkanFactory.hpp"
+//
 
 #include "Clove/Graphics/ShaderCompiler.hpp"
 #include "Clove/Graphics/Vulkan/MemoryAllocator.hpp"
 #include "Clove/Graphics/Vulkan/VulkanBuffer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanComputePipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanComputeQueue.hpp"
+#include "Clove/Graphics/Vulkan/VulkanDescriptor.hpp"
 #include "Clove/Graphics/Vulkan/VulkanDescriptorPool.hpp"
 #include "Clove/Graphics/Vulkan/VulkanDescriptorSetLayout.hpp"
 #include "Clove/Graphics/Vulkan/VulkanFence.hpp"
@@ -15,14 +20,12 @@
 #include "Clove/Graphics/Vulkan/VulkanImageView.hpp"
 #include "Clove/Graphics/Vulkan/VulkanPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanPresentQueue.hpp"
-#include "Clove/Graphics/Vulkan/VulkanRenderPass.hpp"
 #include "Clove/Graphics/Vulkan/VulkanResource.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSampler.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSemaphore.hpp"
 #include "Clove/Graphics/Vulkan/VulkanShader.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSwapchain.hpp"
 #include "Clove/Graphics/Vulkan/VulkanTransferQueue.hpp"
-#include "Clove/Graphics/Vulkan/VulkanDescriptor.hpp"
 
 #include <Clove/Cast.hpp>
 #include <Clove/Log/Log.hpp>
@@ -33,13 +36,13 @@ namespace garlic::clove {
         VkCommandPoolCreateFlags convertCommandPoolCreateFlags(QueueFlags garlicFlags) {
             VkCommandPoolCreateFlags flags{ 0 };
 
-            if((garlicFlags & QueueFlags::Transient) != 0){
+            if((garlicFlags & QueueFlags::Transient) != 0) {
                 flags |= VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
             }
-            if((garlicFlags & QueueFlags::ReuseBuffers) != 0){
+            if((garlicFlags & QueueFlags::ReuseBuffers) != 0) {
                 flags |= VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
             }
-            
+
             return flags;
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanFramebuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFramebuffer.cpp
@@ -1,10 +1,5 @@
 #include "Clove/Graphics/Vulkan/VulkanFramebuffer.hpp"
 
-#include "Clove/Graphics/Vulkan/VulkanImageView.hpp"
-#include "Clove/Graphics/Vulkan/VulkanRenderPass.hpp"
-
-#include <Clove/Cast.hpp>
-
 namespace garlic::clove {
     VulkanFramebuffer::VulkanFramebuffer(DevicePointer device, VkFramebuffer framebuffer)
         : device{ std::move(device) }

--- a/clove/components/core/graphics/source/Vulkan/VulkanPresentQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanPresentQueue.cpp
@@ -1,9 +1,12 @@
+//There seems to be a bug with optional in msvc that stops it compiling. Having this header included here (above VulkanPresentQueue) is a current work around.
+#include "Clove/Graphics/Vulkan/VulkanSwapchain.hpp"
+//
 #include "Clove/Graphics/Vulkan/VulkanPresentQueue.hpp"
+//
 
 #include "Clove/Graphics/Vulkan/VulkanFence.hpp"
 #include "Clove/Graphics/Vulkan/VulkanResult.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSemaphore.hpp"
-#include "Clove/Graphics/Vulkan/VulkanSwapchain.hpp"
 
 #include <Clove/Cast.hpp>
 

--- a/clove/components/core/platform/include/Clove/Platform/Input/Mouse.hpp
+++ b/clove/components/core/platform/include/Clove/Platform/Input/Mouse.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+//There seems to be a bug with optional in msvc that stops it compiling. Having this header included here (before anything) is a current work around.
+#include <optional>
+//
+
 #include "Clove/Platform/Input/MouseButtonCodes.hpp"
 
 #include <Clove/Maths/Vector.hpp>
 #include <bitset>
-#include <optional>
 #include <queue>
 #include <unordered_map>
 


### PR DESCRIPTION
## Summary
Removed / reordered several header files to work around a current compiler bug in MSVC that will cause `optional` to not compile
