### PR TITLE
Scenes in Bulb can now be transitioned from 'Editor time' to 'Game time'

### DIFF
--- a/bulb/CMakeLists.txt
+++ b/bulb/CMakeLists.txt
@@ -20,8 +20,6 @@ add_executable(
 
 		${SOURCE}/Vector3Box.xaml
 		${SOURCE}/Vector3Box.xaml.cs
-
-		${SOURCE}/RelayCommand.cs
 		
 		${SOURCE}/ComponentMenuItemViewModel.cs
 		${SOURCE}/EditorSessionViewModel.cs

--- a/bulb/CMakeLists.txt
+++ b/bulb/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
 		${SOURCE}/LogViewModel.cs
 
 		${SOURCE}/ComponentViewModel.cs
+		${SOURCE}/RigidBodyComponentViewModel.cs
 		${SOURCE}/TransformComponentViewModel.cs
 )
 

--- a/bulb/CMakeLists.txt
+++ b/bulb/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
 		${SOURCE}/LogViewModel.cs
 
 		${SOURCE}/ComponentViewModel.cs
+		${SOURCE}/CollisionShapeComponentViewModel.cs
 		${SOURCE}/RigidBodyComponentViewModel.cs
 		${SOURCE}/TransformComponentViewModel.cs
 )

--- a/bulb/CMakeLists.txt
+++ b/bulb/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
 
 		${SOURCE}/RelayCommand.cs
 		
+		${SOURCE}/ComponentMenuItemViewModel.cs
 		${SOURCE}/EditorSessionViewModel.cs
 		${SOURCE}/SceneViewModel.cs
 		${SOURCE}/EntityViewModel.cs

--- a/bulb/components/membrane/include/Membrane/Application.hpp
+++ b/bulb/components/membrane/include/Membrane/Application.hpp
@@ -7,10 +7,12 @@ namespace garlic::clove {
     class GraphicsImageRenderTarget;
 }
 
-namespace garlic::membrane{
+namespace garlic::membrane {
     class EditorLayer;
     class RuntimeLayer;
     class ViewportSurface;
+    ref class Editor_Stop;
+    ref class Editor_Play;
 }
 
 namespace garlic::membrane {
@@ -40,5 +42,9 @@ public ref class Application {
         void shutdown();
 
         void resize(int width, int height);
+
+    private:
+        void setEditorMode(Editor_Stop ^message);
+        void setRuntimeMode(Editor_Play ^message);
     };
 }

--- a/bulb/components/membrane/include/Membrane/EditorLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorLayer.hpp
@@ -51,6 +51,8 @@ namespace garlic::membrane {
 
         void updateTransform(clove::Entity entity, clove::vec3f position, clove::vec3f rotation, clove::vec3f scale);
         void updateRigidBody(clove::Entity entity, float mass);
+        void updateSphereShape(clove::Entity entity, float radius);
+        void updateCubeShape(clove::Entity entity, clove::vec3f halfExtents);
         void updateName(clove::Entity entity, std::string name);
     };
 }

--- a/bulb/components/membrane/include/Membrane/EditorLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorLayer.hpp
@@ -24,7 +24,7 @@ namespace garlic::membrane {
 
         Scene currentScene;
 
-        clove::Entity editorCamera;
+        clove::Entity editorCamera{};
 
         bool moveMouse{ false };
         clove::vec2i mousePos{};

--- a/bulb/components/membrane/include/Membrane/EditorLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorLayer.hpp
@@ -11,10 +11,6 @@
 #include <vector>
 
 namespace garlic::membrane {
-    //TODO: Runtime and editor are very similar except they are attached / detached and don't run together?
-    //Editor layer pops physics - runtime pushes physics
-    //Editor attaches the editor camera + controls etc.
-
     /**
      * @brief The layer that controls the interaction between the editor and the engine.
      * Is active while 'editing' and allows the user to build a scene

--- a/bulb/components/membrane/include/Membrane/EditorLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorLayer.hpp
@@ -1,18 +1,33 @@
 #pragma once
 
+#include "Membrane/EditorTypes.hpp"
+#include "Membrane/Scene.hpp"
+
 #include <Clove/ECS/Entity.hpp>
 #include <Clove/Layer.hpp>
 #include <Clove/Rendering/Camera.hpp>
+#include <msclr/gcroot.h>
+#include <string_view>
+#include <vector>
 
 namespace garlic::membrane {
+    //TODO: Runtime and editor are very similar except they are attached / detached and don't run together?
+    //Editor layer pops physics - runtime pushes physics
+    //Editor attaches the editor camera + controls etc.
+
     /**
-     * @brief The layer that holds all the editor time components
-     * @details This will be things such as the gizmos, editor camera etc. 
-     * Anything that doesn't contribute to the 'game' which will be removed during play.
+     * @brief The layer that controls the interaction between the editor and the engine.
+     * Is active while 'editing' and allows the user to build a scene
      */
     class EditorLayer : public clove::Layer {
+        friend ref class EditorLayerMessageProxy;
+
         //VARIABLES
     private:
+        msclr::gcroot<EditorLayerMessageProxy ^> proxy;
+
+        Scene currentScene;
+
         clove::Entity editorCamera;
 
         bool moveMouse{ false };
@@ -29,5 +44,17 @@ namespace garlic::membrane {
         clove::InputResponse onInputEvent(clove::InputEvent const &inputEvent) override;
         void onUpdate(clove::DeltaTime const deltaTime) override;
         void onDetach() override;
+
+    private:
+        //TODO: Save and load scene to custom file
+        void saveScene();
+        void loadScene();
+
+        clove::Entity createEntity(std::string_view name = "New Entity");
+        void createComponent(clove::Entity entity, ComponentType componentType);
+
+        void updateTransform(clove::Entity entity, clove::vec3f position, clove::vec3f rotation, clove::vec3f scale);
+        void updateRigidBody(clove::Entity entity, float mass);
+        void updateName(clove::Entity entity, std::string name);
     };
 }

--- a/bulb/components/membrane/include/Membrane/EditorTypes.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorTypes.hpp
@@ -6,6 +6,8 @@ namespace garlic::membrane {
         Transform,
         Mesh,
         PointLight,
+        RigidBody,
+        CollisionShape
     };
 
     public value struct Vector3 {

--- a/bulb/components/membrane/include/Membrane/Messages.hpp
+++ b/bulb/components/membrane/include/Membrane/Messages.hpp
@@ -62,6 +62,8 @@ namespace garlic::membrane {
     };
     public ref class Editor_SaveScene : public EditorMessage {};
     public ref class Editor_LoadScene : public EditorMessage {};
+    public ref class Editor_Play : public EditorMessage {};
+    public ref class Editor_Stop : public EditorMessage {};
 
     //Messages sent from Clove
     public ref class Engine_OnEntityCreated : public EngineMessage {

--- a/bulb/components/membrane/include/Membrane/Messages.hpp
+++ b/bulb/components/membrane/include/Membrane/Messages.hpp
@@ -33,6 +33,18 @@ namespace garlic::membrane {
 
         float mass{};
     };
+    public ref class Editor_UpdateSphereShape : public EditorMessage {
+    public:
+        System::UInt32 entity;
+
+        float radius{};
+    };
+    public ref class Editor_UpdateCubeShape : public EditorMessage {
+    public:
+        System::UInt32 entity;
+
+        Vector3 halfExtents{};
+    };
     public ref class Editor_UpdateName : public EditorMessage {
     public:
         System::UInt32 entity;

--- a/bulb/components/membrane/include/Membrane/Messages.hpp
+++ b/bulb/components/membrane/include/Membrane/Messages.hpp
@@ -27,6 +27,12 @@ namespace garlic::membrane {
         Vector3 rotation;
         Vector3 scale;
     };
+    public ref class Editor_UpdateRigidBody : public EditorMessage {
+    public:
+        System::UInt32 entity;
+
+        float mass{};
+    };
     public ref class Editor_UpdateName : public EditorMessage {
     public:
         System::UInt32 entity;
@@ -75,6 +81,12 @@ namespace garlic::membrane {
         Vector3 position;
         Vector3 rotation;
         Vector3 scale;
+    };
+    public ref class Engine_OnRigidBodyChanged : public EngineMessage {
+    public:
+        System::UInt32 entity;
+
+        float mass{};
     };
     public ref class Engine_OnSceneLoaded : public EngineMessage {
     public:

--- a/bulb/components/membrane/include/Membrane/Messages.hpp
+++ b/bulb/components/membrane/include/Membrane/Messages.hpp
@@ -102,6 +102,18 @@ namespace garlic::membrane {
 
         float mass{};
     };
+    public ref class Engine_OnSphereShapeChanged : public EngineMessage {
+    public:
+        System::UInt32 entity;
+
+        float radius{};
+    };
+    public ref class Engine_OnCubeShapeChanged : public EngineMessage {
+    public:
+        System::UInt32 entity;
+
+        Vector3 halfExtents{};
+    };
     public ref class Engine_OnSceneLoaded : public EngineMessage {
     public:
         System::Collections::Generic::List<Entity^> ^entities;

--- a/bulb/components/membrane/include/Membrane/RuntimeLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/RuntimeLayer.hpp
@@ -1,14 +1,8 @@
 #pragma once
 
-#include "Membrane/EditorTypes.hpp"
-#include "Membrane/MessageHandler.hpp"
 #include "Membrane/Scene.hpp"
 
-#include <Clove/ECS/Entity.hpp>
 #include <Clove/Layer.hpp>
-#include <msclr/gcroot.h>
-#include <string_view>
-#include <vector>
 
 namespace garlic::clove {
     class EntityManager;
@@ -16,17 +10,12 @@ namespace garlic::clove {
 
 namespace garlic::membrane {
     /**
-     * @brief The layer that contains all the run time components.
-     * @details This is the layer that will actually hold the entities that
-     * make up the game and what will be serialsed when saving the scene.
+     * @brief The layer that is active while the game is running.
+     * Deliberately does not handle editor events to simulate the game running.
      */
     class RuntimeLayer : public clove::Layer {
-        friend ref class RuntimeLayerMessageProxy;
-
         //VARIABLES
     private:
-        msclr::gcroot<RuntimeLayerMessageProxy ^> proxy;
-        
         Scene currentScene;
 
         //FUNCTIONS
@@ -36,16 +25,5 @@ namespace garlic::membrane {
         void onAttach() override;
         void onUpdate(clove::DeltaTime const deltaTime) override;
         void onDetach() override;
-
-    private:
-        void saveScene();
-        void loadScene();
-
-        clove::Entity createEntity(std::string_view name = "New Entity");
-        void createComponent(clove::Entity entity, ComponentType componentType);
-
-        void updateTransform(clove::Entity entity, clove::vec3f position, clove::vec3f rotation, clove::vec3f scale);
-        void updateRigidBody(clove::Entity entity, float mass);
-        void updateName(clove::Entity entity, std::string name);
     };
 }

--- a/bulb/components/membrane/include/Membrane/RuntimeLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/RuntimeLayer.hpp
@@ -45,6 +45,7 @@ namespace garlic::membrane {
         void createComponent(clove::Entity entity, ComponentType componentType);
 
         void updateTransform(clove::Entity entity, clove::vec3f position, clove::vec3f rotation, clove::vec3f scale);
+        void updateRigidBody(clove::Entity entity, float mass);
         void updateName(clove::Entity entity, std::string name);
     };
 }

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -3,6 +3,8 @@
 #include "Membrane/EditorLayer.hpp"
 #include "Membrane/RuntimeLayer.hpp"
 #include "Membrane/ViewportSurface.hpp"
+#include "Membrane/Messages.hpp"
+#include "Membrane/MessageHandler.hpp"
 
 #include <Clove/Application.hpp>
 #include <Clove/Audio/Audio.hpp>
@@ -42,6 +44,9 @@ namespace garlic::membrane {
         *runtimeLayer = std::make_shared<RuntimeLayer>();
 
         app->pushLayer(*editorLayer);
+
+        MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_Stop ^>(this, &Application::setEditorMode));
+        MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_Play ^>(this, &Application::setRuntimeMode));
     }
 
     Application::~Application() {
@@ -79,5 +84,15 @@ namespace garlic::membrane {
 
         this->width  = width;
         this->height = height;
+    }
+
+    void Application::setEditorMode(Editor_Stop ^message) {
+        app->popLayer(*runtimeLayer);
+        app->pushLayer(*editorLayer);
+    }
+
+    void Application::setRuntimeMode(Editor_Play ^message) {
+        app->popLayer(*editorLayer);
+        app->pushLayer(*runtimeLayer);
     }
 }

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -41,7 +41,6 @@ namespace garlic::membrane {
         runtimeLayer  = new std::shared_ptr<RuntimeLayer>();
         *runtimeLayer = std::make_shared<RuntimeLayer>();
 
-        app->pushLayer(*runtimeLayer);
         app->pushLayer(*editorLayer);
     }
 

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -12,6 +12,7 @@
 #include <Clove/Components/StaticModelComponent.hpp>
 #include <Clove/Components/TransformComponent.hpp>
 #include <Clove/ECS/EntityManager.hpp>
+#include <Clove/Layers/PhysicsLayer.hpp>
 #include <Clove/Maths/MathsHelpers.hpp>
 #include <Clove/ModelLoader.hpp>
 #include <Clove/Surface.hpp>
@@ -87,7 +88,12 @@ namespace garlic::membrane {
     }
 
     void EditorLayer::onAttach() {
-        auto *const entityManager{ clove::Application::get().getEntityManager() };
+        auto &app{ clove::Application::get() };
+
+        //Pop the physics layer from the application
+        app.popLayer(app.getPhysicsLayer());
+
+        auto *const entityManager{ app.getEntityManager() };
 
         //Add the editor camera outside of the current scene
         editorCamera                                                                  = entityManager->create();

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -225,6 +225,12 @@ namespace garlic::membrane {
             if(currentScene.hasComponent<clove::PointLightComponent>(entity)) {
                 editorEntity->components->Add(ComponentType::PointLight);
             }
+            if(currentScene.hasComponent<clove::CollisionShapeComponent>(entity)) {
+                editorEntity->components->Add(ComponentType::CollisionShape);
+            }
+            if(currentScene.hasComponent<clove::RigidBodyComponent>(entity)) {
+                editorEntity->components->Add(ComponentType::RigidBody);
+            }
 
             loadMessage->entities->Add(editorEntity);
         }

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -93,12 +93,14 @@ namespace garlic::membrane {
         //Pop the physics layer from the application
         app.popLayer(app.getPhysicsLayer());
 
-        auto *const entityManager{ app.getEntityManager() };
-
         //Add the editor camera outside of the current scene
-        editorCamera                                                                  = entityManager->create();
-        entityManager->addComponent<clove::TransformComponent>(editorCamera).position = clove::vec3f{ 0.0f, 0.0f, -10.0f };
-        entityManager->addComponent<clove::CameraComponent>(editorCamera, clove::Camera{ clove::Camera::ProjectionMode::Perspective });
+        if(editorCamera == clove::NullEntity) {
+            auto *const entityManager{ app.getEntityManager() };
+
+            editorCamera                                                                  = entityManager->create();
+            entityManager->addComponent<clove::TransformComponent>(editorCamera).position = clove::vec3f{ 0.0f, 0.0f, -10.0f };
+            entityManager->addComponent<clove::CameraComponent>(editorCamera, clove::Camera{ clove::Camera::ProjectionMode::Perspective });
+        }
 
         loadScene();
     }
@@ -195,7 +197,7 @@ namespace garlic::membrane {
 
     void EditorLayer::onDetach() {
         saveScene();
-        clove::Application::get().getEntityManager()->destroyAll();
+        currentScene.destroyAllEntities();
     }
 
     void EditorLayer::saveScene() {

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -1,26 +1,100 @@
 #include "Membrane/EditorLayer.hpp"
 
 #include "Membrane/MessageHandler.hpp"
+#include "Membrane/Messages.hpp"
+#include "Membrane/NameComponent.hpp"
 
 #include <Clove/Application.hpp>
 #include <Clove/Components/CameraComponent.hpp>
+#include <Clove/Components/CollisionShapeComponent.hpp>
+#include <Clove/Components/PointLightComponent.hpp>
+#include <Clove/Components/RigidBodyComponent.hpp>
+#include <Clove/Components/StaticModelComponent.hpp>
 #include <Clove/Components/TransformComponent.hpp>
 #include <Clove/ECS/EntityManager.hpp>
 #include <Clove/Maths/MathsHelpers.hpp>
 #include <Clove/ModelLoader.hpp>
 #include <Clove/Surface.hpp>
+#include <msclr/marshal_cppstd.h>
+
+namespace garlic::membrane {
+    // clang-format off
+    /**
+     * @brief 
+     */
+    private ref class EditorLayerMessageProxy { //TODO: This will move into editor layer - runtime layer does not respond to editor
+        //VARIABLES
+    private:
+        EditorLayer *layer{ nullptr };
+
+        //FUNCTIONS
+    public:
+        EditorLayerMessageProxy(EditorLayer *layer)
+            : layer{ layer } {
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_CreateEntity ^>(this, &EditorLayerMessageProxy::createEntity));
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_CreateComponent ^>(this, &EditorLayerMessageProxy::createComponent));
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_UpdateRigidBody ^>(this, &EditorLayerMessageProxy::updateRigidBody));
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_UpdateTransform ^>(this, &EditorLayerMessageProxy::updateTransform));
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_UpdateName ^>(this, &EditorLayerMessageProxy::updateName));
+
+
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_SaveScene ^>(this, &EditorLayerMessageProxy::saveScene));
+            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_LoadScene ^>(this, &EditorLayerMessageProxy::loadScene));
+        }
+
+    private:
+        void createEntity(Editor_CreateEntity ^ message) {
+            layer->createEntity();
+        }
+
+        void createComponent(Editor_CreateComponent ^ message){
+            layer->createComponent(message->entity, message->componentType);
+        }
+
+        void updateRigidBody(Editor_UpdateRigidBody^ message){
+            layer->updateRigidBody(message->entity, message->mass);
+        }
+
+        void updateTransform(Editor_UpdateTransform ^ message){
+            clove::vec3f pos{message->position.x, message->position.y, message->position.z};
+            clove::vec3f rot{clove::asRadians(message->rotation.x), clove::asRadians(message->rotation.y), clove::asRadians(message->rotation.z)};
+            clove::vec3f scale{message->scale.x, message->scale.y, message->scale.z};
+
+            layer->updateTransform(message->entity, pos, rot, scale);
+        }
+
+        void updateName(Editor_UpdateName ^ message){
+            System::String ^name{ message->name };
+            layer->updateName(message->entity, msclr::interop::marshal_as<std::string>(name));
+        }
+
+        void saveScene(Editor_SaveScene ^message){
+            layer->saveScene();
+        }
+
+        void loadScene(Editor_LoadScene ^message){
+            layer->loadScene();
+        }
+    };
+    // clang-format on
+}
 
 namespace garlic::membrane {
     EditorLayer::EditorLayer()
-        : clove::Layer{ "Editor Layer" } {
+        : clove::Layer{ "Editor Layer" }
+        , currentScene{ clove::Application::get().getEntityManager(), "scene.yaml" } {
+        proxy = gcnew EditorLayerMessageProxy(this);
     }
 
     void EditorLayer::onAttach() {
         auto *const entityManager{ clove::Application::get().getEntityManager() };
 
+        //Add the editor camera outside of the current scene
         editorCamera                                                                  = entityManager->create();
         entityManager->addComponent<clove::TransformComponent>(editorCamera).position = clove::vec3f{ 0.0f, 0.0f, -10.0f };
         entityManager->addComponent<clove::CameraComponent>(editorCamera, clove::Camera{ clove::Camera::ProjectionMode::Perspective });
+
+        loadScene();
     }
 
     clove::InputResponse EditorLayer::onInputEvent(clove::InputEvent const &inputEvent) {
@@ -34,7 +108,7 @@ namespace garlic::membrane {
                     mousePos     = event.getPos();
                     prevMousePos = event.getPos();
 
-                    moveMouse    = true;
+                    moveMouse = true;
                     return clove::InputResponse::Consumed;
                 } else {
                     moveMouse = false;
@@ -51,6 +125,22 @@ namespace garlic::membrane {
     }
 
     void EditorLayer::onUpdate(clove::DeltaTime const deltaTime) {
+        //Broadcast up any transform changes
+        for(auto &entity : currentScene.getKnownEntities()) {
+            if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
+                auto const &pos{ currentScene.getComponent<clove::TransformComponent>(entity).position };
+                auto const &rot{ clove::quaternionToEuler(currentScene.getComponent<clove::TransformComponent>(entity).rotation) };
+                auto const &scale{ currentScene.getComponent<clove::TransformComponent>(entity).scale };
+
+                Engine_OnTransformChanged ^ message { gcnew Engine_OnTransformChanged };
+                message->entity   = entity;
+                message->position = Vector3(pos.x, pos.y, pos.z);
+                message->rotation = Vector3(clove::asDegrees(rot.x), clove::asDegrees(rot.y), clove::asDegrees(rot.z));
+                message->scale    = Vector3(scale.x, scale.y, scale.z);
+                MessageHandler::sendMessage(message);
+            }
+        }
+
         auto &keyBoard{ clove::Application::get().getSurface()->getKeyboard() };
         auto &mouse{ clove::Application::get().getSurface()->getMouse() };
         auto *const entityManager{ clove::Application::get().getEntityManager() };
@@ -98,6 +188,122 @@ namespace garlic::membrane {
     }
 
     void EditorLayer::onDetach() {
-        clove::Application::get().getEntityManager()->destroy(editorCamera);
+        saveScene();
+        clove::Application::get().getEntityManager()->destroyAll();
+    }
+
+    void EditorLayer::saveScene() {
+        currentScene.save();
+    }
+
+    void EditorLayer::loadScene() {
+        currentScene.load();
+
+        Engine_OnSceneLoaded ^ loadMessage { gcnew Engine_OnSceneLoaded };
+        loadMessage->entities = gcnew System::Collections::Generic::List<Entity ^>{};
+        for(auto entity : currentScene.getKnownEntities()) {
+            Entity ^ editorEntity { gcnew Entity };
+            editorEntity->id         = entity;
+            editorEntity->name       = gcnew System::String(currentScene.getComponent<NameComponent>(entity).name.c_str());
+            editorEntity->components = gcnew System::Collections::Generic::List<ComponentType>{};
+
+            //Add all of the component types for an entity
+            if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
+                editorEntity->components->Add(ComponentType::Transform);
+            }
+            if(currentScene.hasComponent<clove::StaticModelComponent>(entity)) {
+                editorEntity->components->Add(ComponentType::Mesh);
+            }
+            if(currentScene.hasComponent<clove::PointLightComponent>(entity)) {
+                editorEntity->components->Add(ComponentType::PointLight);
+            }
+
+            loadMessage->entities->Add(editorEntity);
+        }
+
+        MessageHandler::sendMessage(loadMessage);
+    }
+
+    clove::Entity EditorLayer::createEntity(std::string_view name) {
+        clove::Entity entity{ currentScene.createEntity() };
+        currentScene.addComponent<NameComponent>(entity, std::string{ std::move(name) });
+
+        Engine_OnEntityCreated ^ message { gcnew Engine_OnEntityCreated };
+        message->entity = entity;
+        message->name   = gcnew System::String(std::string{ std::begin(name), std::end(name) }.c_str());
+        MessageHandler::sendMessage(message);
+
+        return entity;
+    }
+
+    void EditorLayer::createComponent(clove::Entity entity, ComponentType componentType) {
+        bool added{ false };
+        switch(componentType) {
+            case ComponentType::Transform:
+                if(!currentScene.hasComponent<clove::TransformComponent>(entity)) {
+                    currentScene.addComponent<clove::TransformComponent>(entity);
+                    added = true;
+                }
+                break;
+            case ComponentType::Mesh:
+                if(!currentScene.hasComponent<clove::StaticModelComponent>(entity)) {
+                    currentScene.addComponent<clove::StaticModelComponent>(entity, clove::ModelLoader::loadStaticModel(ASSET_DIR "/cube.obj"));//TEMP: Hard coding to a cube for now
+                    added = true;
+                }
+                break;
+            case ComponentType::PointLight:
+                if(!currentScene.hasComponent<clove::PointLightComponent>(entity)) {
+                    currentScene.addComponent<clove::PointLightComponent>(entity);
+                    added = true;
+                }
+                break;
+            case ComponentType::RigidBody:
+                if(!currentScene.hasComponent<clove::RigidBodyComponent>(entity)) {
+                    currentScene.addComponent<clove::RigidBodyComponent>(entity);
+                    added = true;
+                }
+                break;
+            case ComponentType::CollisionShape:
+                if(!currentScene.hasComponent<clove::CollisionShapeComponent>(entity)) {
+                    currentScene.addComponent<clove::CollisionShapeComponent>(entity, clove::CollisionShapeComponent::Cube{});//TEMP: Use basic cube shape
+                    added = true;
+                }
+                break;
+        }
+
+        if(added) {
+            Engine_OnComponentCreated ^ message { gcnew Engine_OnComponentCreated };
+            message->entity        = entity;
+            message->componentType = componentType;
+            MessageHandler::sendMessage(message);
+        }
+    }
+
+    void EditorLayer::updateTransform(clove::Entity entity, clove::vec3f position, clove::vec3f rotation, clove::vec3f scale) {
+        if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
+            auto &transform{ currentScene.getComponent<clove::TransformComponent>(entity) };
+            transform.position = position;
+            transform.rotation = rotation;
+            transform.scale    = scale;
+        }
+    }
+
+    void EditorLayer::updateRigidBody(clove::Entity entity, float mass) {
+        if(currentScene.hasComponent<clove::RigidBodyComponent>(entity)) {
+            auto &rigidBody{ currentScene.getComponent<clove::RigidBodyComponent>(entity) };
+            rigidBody.mass = mass;
+
+            //Pipe back up the change to the editor
+            Engine_OnRigidBodyChanged ^ message { gcnew Engine_OnRigidBodyChanged };
+            message->entity = entity;
+            message->mass   = mass;
+            MessageHandler::sendMessage(message);
+        }
+    }
+
+    void EditorLayer::updateName(clove::Entity entity, std::string name) {
+        if(currentScene.hasComponent<NameComponent>(entity)) {
+            currentScene.getComponent<NameComponent>(entity).name = std::move(name);
+        }
     }
 }

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -292,7 +292,7 @@ namespace garlic::membrane {
                 break;
             case ComponentType::CollisionShape:
                 if(!currentScene.hasComponent<clove::CollisionShapeComponent>(entity)) {
-                    currentScene.addComponent<clove::CollisionShapeComponent>(entity, clove::CollisionShapeComponent::Cube{});//TEMP: Use basic cube shape
+                    currentScene.addComponent<clove::CollisionShapeComponent>(entity, clove::CollisionShapeComponent::Sphere{ 1.0f });//TEMP: Defaulting as sphere. See CollisionShapeComponentViewModel
                     added = true;
                 }
                 break;
@@ -329,11 +329,25 @@ namespace garlic::membrane {
     }
 
     void EditorLayer::updateSphereShape(clove::Entity entity, float radius) {
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, clove::LogLevel::Debug, "Update sphere: {0}", radius);
+        if(currentScene.hasComponent<clove::CollisionShapeComponent>(entity)) {
+            currentScene.getComponent<clove::CollisionShapeComponent>(entity).shape = clove::CollisionShapeComponent::Sphere{ radius };
+
+            Engine_OnSphereShapeChanged ^ message { gcnew Engine_OnSphereShapeChanged };
+            message->entity = entity;
+            message->radius = radius;
+            MessageHandler::sendMessage(message);
+        }
     }
 
     void EditorLayer::updateCubeShape(clove::Entity entity, clove::vec3f halfExtents) {
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, clove::LogLevel::Debug, "Update cube: {0}, {1}, {2}", halfExtents.x, halfExtents.y, halfExtents.z);
+        if(currentScene.hasComponent<clove::CollisionShapeComponent>(entity)) {
+            currentScene.getComponent<clove::CollisionShapeComponent>(entity).shape = clove::CollisionShapeComponent::Cube{ halfExtents };
+
+            Engine_OnCubeShapeChanged ^ message { gcnew Engine_OnCubeShapeChanged };
+            message->entity      = entity;
+            message->halfExtents = Vector3{ halfExtents.x, halfExtents.y, halfExtents.z };
+            MessageHandler::sendMessage(message);
+        }
     }
 
     void EditorLayer::updateName(clove::Entity entity, std::string name) {

--- a/bulb/components/membrane/source/RuntimeLayer.cpp
+++ b/bulb/components/membrane/source/RuntimeLayer.cpp
@@ -1,8 +1,13 @@
 #include "Membrane/RuntimeLayer.hpp"
 
-#include <Clove/Application.hpp>
+#include "Membrane/MessageHandler.hpp"
+#include "Membrane/Messages.hpp"
 
+#include <Clove/Application.hpp>
+#include <Clove/Components/TransformComponent.hpp>
 #include <Clove/ECS/EntityManager.hpp>
+#include <Clove/Layers/PhysicsLayer.hpp>
+#include <Clove/Maths/MathsHelpers.hpp>
 #include <Clove/ModelLoader.hpp>
 
 namespace garlic::membrane {
@@ -12,11 +17,17 @@ namespace garlic::membrane {
     }
 
     void RuntimeLayer::onAttach() {
+        auto &app{ clove::Application::get() };
+
+        //push the physics layer from the application
+        app.pushLayer(app.getPhysicsLayer());
+
         currentScene.load();
     }
 
     void RuntimeLayer::onUpdate(clove::DeltaTime const deltaTime) {
-        /*for(auto &entity : currentScene.getKnownEntities()) {
+        //Make sure any movement is reflected in editor
+        for(auto &entity : currentScene.getKnownEntities()) {
             if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
                 auto const &pos{ currentScene.getComponent<clove::TransformComponent>(entity).position };
                 auto const &rot{ clove::quaternionToEuler(currentScene.getComponent<clove::TransformComponent>(entity).rotation) };
@@ -29,7 +40,7 @@ namespace garlic::membrane {
                 message->scale    = Vector3(scale.x, scale.y, scale.z);
                 MessageHandler::sendMessage(message);
             }
-        }*/
+        }
     }
 
     void RuntimeLayer::onDetach() {

--- a/bulb/components/membrane/source/RuntimeLayer.cpp
+++ b/bulb/components/membrane/source/RuntimeLayer.cpp
@@ -75,11 +75,6 @@ namespace garlic::membrane {
     }
 
     void RuntimeLayer::onAttach() {
-        auto lightEnt{ createEntity("Point Light") };
-        createComponent(lightEnt, ComponentType::Transform);
-        createComponent(lightEnt, ComponentType::PointLight);
-
-        currentScene.getComponent<clove::TransformComponent>(lightEnt).position = clove::vec3f{ 5.0f, 0.0f, 0.0f };
     }
 
     void RuntimeLayer::onUpdate(clove::DeltaTime const deltaTime) {

--- a/bulb/components/membrane/source/RuntimeLayer.cpp
+++ b/bulb/components/membrane/source/RuntimeLayer.cpp
@@ -1,95 +1,22 @@
 #include "Membrane/RuntimeLayer.hpp"
 
-#include "Membrane/Messages.hpp"
-#include "Membrane/NameComponent.hpp"
-
 #include <Clove/Application.hpp>
-#include <Clove/Components/CollisionShapeComponent.hpp>
-#include <Clove/Components/PointLightComponent.hpp>
-#include <Clove/Components/RigidBodyComponent.hpp>
-#include <Clove/Components/StaticModelComponent.hpp>
-#include <Clove/Components/TransformComponent.hpp>
+
 #include <Clove/ECS/EntityManager.hpp>
 #include <Clove/ModelLoader.hpp>
-#include <msclr/marshal_cppstd.h>
-
-namespace garlic::membrane {
-    // clang-format off
-    /**
-     * @brief 
-     */
-    private ref class RuntimeLayerMessageProxy {
-        //VARIABLES
-    private:
-        class RuntimeLayer *layer{ nullptr };
-
-        //FUNCTIONS
-    public:
-        RuntimeLayerMessageProxy(class RuntimeLayer *layer)
-            : layer{ layer } {
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_CreateEntity ^>(this, &RuntimeLayerMessageProxy::createEntity));
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_CreateComponent ^>(this, &RuntimeLayerMessageProxy::createComponent));
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_UpdateRigidBody ^>(this, &RuntimeLayerMessageProxy::updateRigidBody));
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_UpdateTransform ^>(this, &RuntimeLayerMessageProxy::updateTransform));
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_UpdateName ^>(this, &RuntimeLayerMessageProxy::updateName));
-
-
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_SaveScene ^>(this, &RuntimeLayerMessageProxy::saveScene));
-            MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_LoadScene ^>(this, &RuntimeLayerMessageProxy::loadScene));
-        }
-
-    private:
-        void createEntity(Editor_CreateEntity ^ message) {
-            layer->createEntity();
-        }
-
-        void createComponent(Editor_CreateComponent ^ message){
-            layer->createComponent(message->entity, message->componentType);
-        }
-
-        void updateRigidBody(Editor_UpdateRigidBody^ message){
-            layer->updateRigidBody(message->entity, message->mass);
-        }
-
-        void updateTransform(Editor_UpdateTransform ^ message){
-            clove::vec3f pos{message->position.x, message->position.y, message->position.z};
-            clove::vec3f rot{clove::asRadians(message->rotation.x), clove::asRadians(message->rotation.y), clove::asRadians(message->rotation.z)};
-            clove::vec3f scale{message->scale.x, message->scale.y, message->scale.z};
-
-            layer->updateTransform(message->entity, pos, rot, scale);
-        }
-
-        void updateName(Editor_UpdateName ^ message){
-            System::String ^name{ message->name };
-            layer->updateName(message->entity, msclr::interop::marshal_as<std::string>(name));
-        }
-
-        void saveScene(Editor_SaveScene ^message){
-            layer->saveScene();
-        }
-
-        void loadScene(Editor_LoadScene ^message){
-            layer->loadScene();
-        }
-    };
-    // clang-format on
-}
 
 namespace garlic::membrane {
     RuntimeLayer::RuntimeLayer()
         : clove::Layer{ "Runtime Layer" }
         , currentScene{ clove::Application::get().getEntityManager(), "scene.yaml" } {
-        proxy = gcnew RuntimeLayerMessageProxy(this);
     }
 
     void RuntimeLayer::onAttach() {
+        currentScene.load();
     }
 
     void RuntimeLayer::onUpdate(clove::DeltaTime const deltaTime) {
-        static float time{ 0.0f };
-        time += deltaTime;
-
-        for(auto &entity : currentScene.getKnownEntities()) {
+        /*for(auto &entity : currentScene.getKnownEntities()) {
             if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
                 auto const &pos{ currentScene.getComponent<clove::TransformComponent>(entity).position };
                 auto const &rot{ clove::quaternionToEuler(currentScene.getComponent<clove::TransformComponent>(entity).rotation) };
@@ -102,125 +29,10 @@ namespace garlic::membrane {
                 message->scale    = Vector3(scale.x, scale.y, scale.z);
                 MessageHandler::sendMessage(message);
             }
-        }
+        }*/
     }
 
     void RuntimeLayer::onDetach() {
         currentScene.destroyAllEntities();
-    }
-
-    void RuntimeLayer::saveScene() {
-        currentScene.save();
-    }
-
-    void RuntimeLayer::loadScene() {
-        currentScene.load();
-
-        Engine_OnSceneLoaded ^ loadMessage { gcnew Engine_OnSceneLoaded };
-        loadMessage->entities = gcnew System::Collections::Generic::List<Entity ^>{};
-        for(auto entity : currentScene.getKnownEntities()) {
-            Entity ^ editorEntity { gcnew Entity };
-            editorEntity->id         = entity;
-            editorEntity->name       = gcnew System::String(currentScene.getComponent<NameComponent>(entity).name.c_str());
-            editorEntity->components = gcnew System::Collections::Generic::List<ComponentType>{};
-
-            //Add all of the component types for an entity
-            if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
-                editorEntity->components->Add(ComponentType::Transform);
-            }
-            if(currentScene.hasComponent<clove::StaticModelComponent>(entity)) {
-                editorEntity->components->Add(ComponentType::Mesh);
-            }
-            if(currentScene.hasComponent<clove::PointLightComponent>(entity)) {
-                editorEntity->components->Add(ComponentType::PointLight);
-            }
-
-            loadMessage->entities->Add(editorEntity);
-        }
-
-        MessageHandler::sendMessage(loadMessage);
-    }
-
-    clove::Entity RuntimeLayer::createEntity(std::string_view name) {
-        clove::Entity entity{ currentScene.createEntity() };
-        currentScene.addComponent<NameComponent>(entity, std::string{ std::move(name) });
-
-        Engine_OnEntityCreated ^ message { gcnew Engine_OnEntityCreated };
-        message->entity = entity;
-        message->name   = gcnew System::String(std::string{ std::begin(name), std::end(name) }.c_str());
-        MessageHandler::sendMessage(message);
-
-        return entity;
-    }
-
-    void RuntimeLayer::createComponent(clove::Entity entity, ComponentType componentType) {
-        bool added{ false };
-        switch(componentType) {
-            case ComponentType::Transform:
-                if(!currentScene.hasComponent<clove::TransformComponent>(entity)) {
-                    currentScene.addComponent<clove::TransformComponent>(entity);
-                    added = true;
-                }
-                break;
-            case ComponentType::Mesh:
-                if(!currentScene.hasComponent<clove::StaticModelComponent>(entity)) {
-                    currentScene.addComponent<clove::StaticModelComponent>(entity, clove::ModelLoader::loadStaticModel(ASSET_DIR "/cube.obj"));//TEMP: Hard coding to a cube for now
-                    added = true;
-                }
-                break;
-            case ComponentType::PointLight:
-                if(!currentScene.hasComponent<clove::PointLightComponent>(entity)) {
-                    currentScene.addComponent<clove::PointLightComponent>(entity);
-                    added = true;
-                }
-                break;
-            case ComponentType::RigidBody:
-                if(!currentScene.hasComponent<clove::RigidBodyComponent>(entity)) {
-                    currentScene.addComponent<clove::RigidBodyComponent>(entity);
-                    added = true;
-                }
-                break;
-            case ComponentType::CollisionShape:
-                if(!currentScene.hasComponent<clove::CollisionShapeComponent>(entity)) {
-                    currentScene.addComponent<clove::CollisionShapeComponent>(entity, clove::CollisionShapeComponent::Cube{});//TEMP: Use basic cube shape
-                    added = true;
-                }
-                break;
-        }
-
-        if(added) {
-            Engine_OnComponentCreated ^ message { gcnew Engine_OnComponentCreated };
-            message->entity        = entity;
-            message->componentType = componentType;
-            MessageHandler::sendMessage(message);
-        }
-    }
-
-    void RuntimeLayer::updateTransform(clove::Entity entity, clove::vec3f position, clove::vec3f rotation, clove::vec3f scale) {
-        if(currentScene.hasComponent<clove::TransformComponent>(entity)) {
-            auto &transform{ currentScene.getComponent<clove::TransformComponent>(entity) };
-            transform.position = position;
-            transform.rotation = rotation;
-            transform.scale    = scale;
-        }
-    }
-
-    void RuntimeLayer::updateRigidBody(clove::Entity entity, float mass) {
-        if(currentScene.hasComponent<clove::RigidBodyComponent>(entity)) {
-            auto &rigidBody{ currentScene.getComponent<clove::RigidBodyComponent>(entity) };
-            rigidBody.mass = mass;
-
-            //Pipe back up the change to the editor
-            Engine_OnRigidBodyChanged ^ message { gcnew Engine_OnRigidBodyChanged };
-            message->entity = entity;
-            message->mass   = mass;
-            MessageHandler::sendMessage(message);
-        }
-    }
-
-    void RuntimeLayer::updateName(clove::Entity entity, std::string name) {
-        if(currentScene.hasComponent<NameComponent>(entity)) {
-            currentScene.getComponent<NameComponent>(entity).name = std::move(name);
-        }
     }
 }

--- a/bulb/components/membrane/source/Scene.cpp
+++ b/bulb/components/membrane/source/Scene.cpp
@@ -2,7 +2,9 @@
 
 #include "Membrane/NameComponent.hpp"
 
+#include <Clove/Components/CollisionShapeComponent.hpp>
 #include <Clove/Components/PointLightComponent.hpp>
+#include <Clove/Components/RigidBodyComponent.hpp>
 #include <Clove/Components/StaticModelComponent.hpp>
 #include <Clove/Components/TransformComponent.hpp>
 #include <Clove/ModelLoader.hpp>
@@ -73,6 +75,10 @@ namespace garlic::membrane {
                     manager->addComponent<StaticModelComponent>(entity, componentNode.as<StaticModelComponent>());
                 } else if(componentNode["id"].as<size_t>() == typeid(PointLightComponent).hash_code()) {
                     manager->addComponent<PointLightComponent>(entity, componentNode.as<PointLightComponent>());
+                } else if(componentNode["id"].as<size_t>() == typeid(CollisionShapeComponent).hash_code()) {
+                    manager->addComponent<CollisionShapeComponent>(entity, componentNode.as<CollisionShapeComponent>());
+                } else if(componentNode["id"].as<size_t>() == typeid(RigidBodyComponent).hash_code()) {
+                    manager->addComponent<RigidBodyComponent>(entity, componentNode.as<RigidBodyComponent>());
                 }
             }
 

--- a/bulb/components/membrane/source/Scene.cpp
+++ b/bulb/components/membrane/source/Scene.cpp
@@ -61,6 +61,11 @@ namespace garlic::membrane {
         }
         knownEntities.clear();
 
+        //File won't exist if we haven't saved anything yet
+        if(!std::filesystem::exists(sceneFile)) {
+            return;
+        }
+
         auto loadResult{ loadYaml(sceneFile) };
         serialiser::Node rootNode{ loadResult.getValue() };
 

--- a/bulb/components/membrane/source/Scene.cpp
+++ b/bulb/components/membrane/source/Scene.cpp
@@ -46,6 +46,8 @@ namespace garlic::membrane {
             serialiseComponent<TransformComponent>(entityNode, *manager, entity);
             serialiseComponent<StaticModelComponent>(entityNode, *manager, entity);
             serialiseComponent<PointLightComponent>(entityNode, *manager, entity);
+            serialiseComponent<CollisionShapeComponent>(entityNode, *manager, entity);
+            serialiseComponent<RigidBodyComponent>(entityNode, *manager, entity);
 
             rootNode["entities"].pushBack(entityNode);
         }

--- a/bulb/components/ui/CMakeLists.txt
+++ b/bulb/components/ui/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 add_library(
     BulbUI SHARED
 
+	${SOURCE}/RelayCommand.cs
     ${SOURCE}/ViewModel.cs
 )
 

--- a/bulb/components/ui/source/RelayCommand.cs
+++ b/bulb/components/ui/source/RelayCommand.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Windows.Input;
 
-namespace Garlic.Bulb
-{
+namespace Garlic.Bulb {
     /// <summary>
     /// Simple RelayCommand that invokes an action when executed.
     /// </summary>
-    public class RelayCommand : ICommand
-    {
+    public class RelayCommand : ICommand {
         public event EventHandler CanExecuteChanged = (sender, e) => { };
 
         private Action action;

--- a/bulb/source/CollisionShapeComponentViewModel.cs
+++ b/bulb/source/CollisionShapeComponentViewModel.cs
@@ -92,8 +92,8 @@ namespace Garlic.Bulb {
         public CollisionShapeCubeChanged OnCubeShapeChanged;
 
         public CollisionShapeComponentViewModel(string name, Membrane.ComponentType type) : base(name, type) {
-            //Start off as a sphere
-            OnShapeTypeChanged(ShapeType.Sphere);
+            //TODO: Hard coding as a sphere. Should be synced to what ever the component is added as
+            OnShapeTypeChanged(ShapeType.Sphere, false);
         }
 
         public void UpdateSphereShape(float radius) {
@@ -108,19 +108,23 @@ namespace Garlic.Bulb {
             OnPropertyChanged(nameof(HalfExtentsZ));
         }
 
-        private void OnShapeTypeChanged(ShapeType newType) {
+        private void OnShapeTypeChanged(ShapeType newType, bool invokeDelegates = true) {
             CurrentShapeType = newType;
 
             switch (CurrentShapeType) {
                 case ShapeType.Sphere:
                     RadiusVisibility = Visibility.Visible;
                     HalfExtentsVisibility = Visibility.Collapsed;
-                    OnSphereShapeChanged?.Invoke(radius);
+                    if (invokeDelegates) {
+                        OnSphereShapeChanged?.Invoke(radius);
+                    }
                     break;
                 case ShapeType.Cube:
                     RadiusVisibility = Visibility.Collapsed;
                     HalfExtentsVisibility = Visibility.Visible;
-                    OnCubeShapeChanged?.Invoke(halfExtents);
+                    if (invokeDelegates) {
+                        OnCubeShapeChanged?.Invoke(halfExtents);
+                    }
                     break;
             }
 

--- a/bulb/source/CollisionShapeComponentViewModel.cs
+++ b/bulb/source/CollisionShapeComponentViewModel.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using Membrane = garlic.membrane;
+
+namespace Garlic.Bulb {
+    public class CollisionShapeComponentViewModel : ComponentViewModel {
+        public enum ShapeType {
+            Sphere,
+            Cube
+        };
+
+        public class ShapeTypeViewModel {
+            public string Name { get; }
+            public ShapeType Type { get; }
+            public ICommand OnSelectedCommand { get; }
+
+            public ShapeTypeViewModel(string name, ShapeType type, ICommand onSelectedCommand) {
+                Name = name;
+                Type = type;
+                OnSelectedCommand = onSelectedCommand;
+            }
+        }
+
+        public float Radius { get; set; }
+        public Membrane.Vector3 HalfExtents { get; set; }
+
+        public ShapeType CurrentShapeType {
+            get { return currentShapeType; }
+            private set {
+                currentShapeType = value;
+                OnPropertyChanged(nameof(CurrentShapeType));
+            }
+        }
+        private ShapeType currentShapeType;
+
+        public ObservableCollection<ShapeTypeViewModel> AvailableShapes { get; } = new ObservableCollection<ShapeTypeViewModel>();
+
+        public Visibility RadiusVisibility {
+            get { return radiusVisibility; }
+            private set {
+                radiusVisibility = value;
+                OnPropertyChanged(nameof(RadiusVisibility));
+            }
+        }
+        private Visibility radiusVisibility = Visibility.Visible;
+
+        public Visibility HalfExtentsVisibility {
+            get { return halfExtentsVisibility; }
+            private set {
+                halfExtentsVisibility = value;
+                OnPropertyChanged(nameof(HalfExtentsVisibility));
+            }
+        }
+        private Visibility halfExtentsVisibility = Visibility.Visible;
+
+        public CollisionShapeComponentViewModel(string name, Membrane.ComponentType type) : base(name, type) {
+            //Start off as a sphere
+            OnShapeTypeChanged(ShapeType.Sphere);
+        }
+
+        private void OnShapeTypeChanged(ShapeType newType) {
+            CurrentShapeType = newType;
+
+            switch (CurrentShapeType) {
+                case ShapeType.Sphere:
+                    RadiusVisibility = Visibility.Visible;
+                    HalfExtentsVisibility = Visibility.Collapsed;
+                    break;
+                case ShapeType.Cube:
+                    RadiusVisibility = Visibility.Collapsed;
+                    HalfExtentsVisibility = Visibility.Visible;
+                    break;
+            }
+
+            //Update the available shapes to remove the selected one
+            var shapeTypes = Enum.GetValues(typeof(ShapeType)).Cast<ShapeType>();
+
+            AvailableShapes.Clear();
+            foreach (ShapeType shape in shapeTypes) {
+                if (shape != CurrentShapeType) {
+                    AvailableShapes.Add(new ShapeTypeViewModel($"{shape}", shape, new RelayCommand(() => OnShapeTypeChanged(shape))));
+                }
+            }
+        }
+    }
+}

--- a/bulb/source/CollisionShapeComponentViewModel.cs
+++ b/bulb/source/CollisionShapeComponentViewModel.cs
@@ -24,8 +24,37 @@ namespace Garlic.Bulb {
             }
         }
 
-        public float Radius { get; set; }
-        public Membrane.Vector3 HalfExtents { get; set; }
+        public string Radius {
+            get { return radius.ToString(); }
+            set {
+                float.TryParse(value, out var number);
+                OnSphereShapeChanged?.Invoke(number);
+            }
+        }
+        private float radius = 1.0f;
+
+        public string HalfExtentsX {
+            get { return halfExtents.x.ToString(); }
+            set {
+                float.TryParse(value, out var number);
+                OnCubeShapeChanged?.Invoke(new Membrane.Vector3(number, halfExtents.y, halfExtents.z));
+            }
+        }
+        public string HalfExtentsY {
+            get { return halfExtents.y.ToString(); }
+            set {
+                float.TryParse(value, out var number);
+                OnCubeShapeChanged?.Invoke(new Membrane.Vector3(halfExtents.x, number, halfExtents.z));
+            }
+        }
+        public string HalfExtentsZ {
+            get { return halfExtents.z.ToString(); }
+            set {
+                float.TryParse(value, out var number);
+                OnCubeShapeChanged?.Invoke(new Membrane.Vector3(halfExtents.x, halfExtents.y, number));
+            }
+        }
+        private Membrane.Vector3 halfExtents = new Membrane.Vector3(0.5f, 0.5f, 0.5f);
 
         public ShapeType CurrentShapeType {
             get { return currentShapeType; }
@@ -56,9 +85,27 @@ namespace Garlic.Bulb {
         }
         private Visibility halfExtentsVisibility = Visibility.Visible;
 
+        public delegate void CollisionShapeSphereChanged(float radius);
+        public delegate void CollisionShapeCubeChanged(Membrane.Vector3 halfExtents);
+
+        public CollisionShapeSphereChanged OnSphereShapeChanged;
+        public CollisionShapeCubeChanged OnCubeShapeChanged;
+
         public CollisionShapeComponentViewModel(string name, Membrane.ComponentType type) : base(name, type) {
             //Start off as a sphere
             OnShapeTypeChanged(ShapeType.Sphere);
+        }
+
+        public void UpdateSphereShape(float radius) {
+            this.radius = radius;
+            OnPropertyChanged(nameof(Radius));
+        }
+
+        public void UpdateCubeShape(Membrane.Vector3 halfExtents) {
+            this.halfExtents = halfExtents;
+            OnPropertyChanged(nameof(HalfExtentsX));
+            OnPropertyChanged(nameof(HalfExtentsY));
+            OnPropertyChanged(nameof(HalfExtentsZ));
         }
 
         private void OnShapeTypeChanged(ShapeType newType) {
@@ -68,10 +115,12 @@ namespace Garlic.Bulb {
                 case ShapeType.Sphere:
                     RadiusVisibility = Visibility.Visible;
                     HalfExtentsVisibility = Visibility.Collapsed;
+                    OnSphereShapeChanged?.Invoke(radius);
                     break;
                 case ShapeType.Cube:
                     RadiusVisibility = Visibility.Collapsed;
                     HalfExtentsVisibility = Visibility.Visible;
+                    OnCubeShapeChanged?.Invoke(halfExtents);
                     break;
             }
 

--- a/bulb/source/ComponentMenuItemViewModel.cs
+++ b/bulb/source/ComponentMenuItemViewModel.cs
@@ -1,0 +1,14 @@
+using System.Windows.Input;
+using Membrane = garlic.membrane;
+
+namespace Garlic.Bulb {
+    public class ComponentMenuItemViewModel : ViewModel {
+        public Membrane.ComponentType ComponentType { get; }
+        public ICommand OnSelectedCommand { get; }
+
+        public ComponentMenuItemViewModel(Membrane.ComponentType componentType, ICommand onSelectedCommand) {
+            ComponentType = componentType;
+            OnSelectedCommand = onSelectedCommand;
+        }
+    }
+}

--- a/bulb/source/ComponentViewModel.cs
+++ b/bulb/source/ComponentViewModel.cs
@@ -1,15 +1,16 @@
-namespace Garlic.Bulb
-{
+using Membrane = garlic.membrane;
+
+namespace Garlic.Bulb {
     /// <summary>
     /// The base viewmodel for all components
     /// </summary>
-    public class ComponentViewModel : ViewModel
-    {
-        public string Name
-        {
-            get { return name; }
-            set { name = value; OnPropertyChanged(nameof(name)); }
+    public class ComponentViewModel : ViewModel {
+        public string Name { get; }
+        public Membrane.ComponentType Type { get; }
+
+        public ComponentViewModel(string name, Membrane.ComponentType type) {
+            Name = name;
+            Type = type;
         }
-        private string name = "";
     }
 }

--- a/bulb/source/EditorSessionViewModel.cs
+++ b/bulb/source/EditorSessionViewModel.cs
@@ -10,6 +10,8 @@ namespace Garlic.Bulb {
 	public class EditorSessionViewModel : ViewModel {
 		public ICommand LoadSceneCommand { get; }
 		public ICommand SaveSceneCommand { get; }
+		public ICommand PlayCommand { get; }
+		public ICommand StopCommand { get; }
 
 		public SceneViewModel Scene {
 			get { return scene; }
@@ -22,6 +24,24 @@ namespace Garlic.Bulb {
 
 		public LogViewModel Log { get; } = new LogViewModel();
 
+		public bool IsPlayButtonEnabled {
+            get { return isPlayButtonEnabled; }
+            set {
+				isPlayButtonEnabled = value;
+				OnPropertyChanged(nameof(IsPlayButtonEnabled));
+            }
+        }
+		private bool isPlayButtonEnabled = true;
+
+		public bool IsStopButtonEnabled {
+			get { return isStopButtonEnabled; }
+			set {
+				isStopButtonEnabled = value;
+				OnPropertyChanged(nameof(IsStopButtonEnabled));
+			}
+		}
+		private bool isStopButtonEnabled = false;
+
 		public EditorSessionViewModel() {
 			//Bind to messages
 			Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnSceneLoaded>(OnSceneLoaded);
@@ -33,10 +53,24 @@ namespace Garlic.Bulb {
 			SaveSceneCommand = new RelayCommand(() => {
 				Membrane.MessageHandler.sendMessage(new Membrane.Editor_SaveScene());
 			});
+			PlayCommand = new RelayCommand(Play);
+			StopCommand = new RelayCommand(Stop);
 		}
 
 		private void OnSceneLoaded(Membrane.Engine_OnSceneLoaded message) {
 			Scene = new SceneViewModel(message.entities);
+		}
+
+		private void Play() {
+			IsPlayButtonEnabled = false;
+			IsStopButtonEnabled = true;
+			Membrane.MessageHandler.sendMessage(new Membrane.Editor_Play());
+		}
+
+		private void Stop() {
+			IsPlayButtonEnabled = true;
+			IsStopButtonEnabled = false;
+			Membrane.MessageHandler.sendMessage(new Membrane.Editor_Stop());
 		}
 	}
 }

--- a/bulb/source/EntityViewModel.cs
+++ b/bulb/source/EntityViewModel.cs
@@ -7,101 +7,99 @@ using System.Windows.Input;
 using Membrane = garlic.membrane;
 
 namespace Garlic.Bulb {
-	public class EntityViewModel : ViewModel {
-		public uint EntityId { get; set; }
+    public class EntityViewModel : ViewModel {
+        public uint EntityId { get; set; }
 
-		public string Name {
-			get { return name; }
-			set {
-				name = value;
-				OnPropertyChanged(nameof(Name));
+        public string Name {
+            get { return name; }
+            set {
+                name = value;
+                OnPropertyChanged(nameof(Name));
 
-				var message = new Membrane.Editor_UpdateName();
-				message.entity = EntityId;
-				message.name = name;
-				
-				Membrane.MessageHandler.sendMessage(message);
-			}
-		}
-		private string name = "New Entity";
+                var message = new Membrane.Editor_UpdateName();
+                message.entity = EntityId;
+                message.name = name;
 
-		public ObservableCollection<ComponentViewModel> Components { get; } = new ObservableCollection<ComponentViewModel>();
+                Membrane.MessageHandler.sendMessage(message);
+            }
+        }
+        private string name = "New Entity";
 
-		public ICommand SelectedCommand { get; }
+        public ObservableCollection<ComponentViewModel> Components { get; } = new ObservableCollection<ComponentViewModel>();
 
-		public delegate void SelectionHandler(EntityViewModel viewModel);
-		public SelectionHandler OnSelected;
+        public ICommand SelectedCommand { get; }
 
-		public EntityViewModel() {
-			//Bind to messages
-			Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnComponentCreated>(OnComponentCreated);
-			Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnTransformChanged>(OnTransformChanged);
+        public delegate void SelectionHandler(EntityViewModel viewModel);
+        public SelectionHandler OnSelected;
 
-			//Set up commands
-			SelectedCommand = new RelayCommand(() => OnSelected?.Invoke(this));
-		}
+        public EntityViewModel() {
+            //Bind to messages
+            Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnComponentCreated>(OnComponentCreated);
+            Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnTransformChanged>(OnTransformChanged);
 
-		public EntityViewModel(List<Membrane.ComponentType> components) : this() {
-			foreach (var componentType in components) {
-				Components.Add(CreateComponentViewModel(componentType));
-			}
-		}
+            //Set up commands
+            SelectedCommand = new RelayCommand(() => OnSelected?.Invoke(this));
+        }
 
-		public void AddComponent(Membrane.ComponentType type) {
-			var message = new Membrane.Editor_CreateComponent();
-			message.entity = EntityId;
-			message.componentType = type;
+        public EntityViewModel(List<Membrane.ComponentType> components) : this() {
+            foreach (var componentType in components) {
+                Components.Add(CreateComponentViewModel(componentType));
+            }
+        }
 
-			Membrane.MessageHandler.sendMessage(message);
-		}
+        public void AddComponent(Membrane.ComponentType type) {
+            var message = new Membrane.Editor_CreateComponent();
+            message.entity = EntityId;
+            message.componentType = type;
 
-		private void OnComponentCreated(Membrane.Engine_OnComponentCreated message) {
-			if(EntityId == message.entity) {
-				Components.Add(CreateComponentViewModel(message.componentType));
-			}
-		}
+            Membrane.MessageHandler.sendMessage(message);
+        }
 
-		private ComponentViewModel CreateComponentViewModel(Membrane.ComponentType type) {
-			ComponentViewModel componentVm;
+        private void OnComponentCreated(Membrane.Engine_OnComponentCreated message) {
+            if (EntityId == message.entity) {
+                Components.Add(CreateComponentViewModel(message.componentType));
+            }
+        }
 
-			switch(type) {
-				case Membrane.ComponentType.Transform: {
-					var transformComp = new TransformComponentViewModel();
-					transformComp.OnTransformChanged = UpdateTransform;
+        private ComponentViewModel CreateComponentViewModel(Membrane.ComponentType type) {
+            ComponentViewModel componentVm;
 
-					componentVm = transformComp;
-				}
-				break;
-				default:
-					componentVm = new ComponentViewModel();
-					break;
-			}
+            switch (type) {
+                case Membrane.ComponentType.Transform: {
+                    var transformComp = new TransformComponentViewModel($"{type}", type);
+                    transformComp.OnTransformChanged = UpdateTransform;
 
-			componentVm.Name = $"{type}";
+                    componentVm = transformComp;
+                }
+                break;
+                default:
+                    componentVm = new ComponentViewModel($"{type}", type);
+                    break;
+            }
 
-			return componentVm;
-		}
+            return componentVm;
+        }
 
-		private void UpdateTransform(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale) {
-			var message = new Membrane.Editor_UpdateTransform();
-			message.entity = EntityId;
-			message.position = position;
-			message.rotation = rotation;
-			message.scale = scale;
+        private void UpdateTransform(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale) {
+            var message = new Membrane.Editor_UpdateTransform();
+            message.entity = EntityId;
+            message.position = position;
+            message.rotation = rotation;
+            message.scale = scale;
 
-			Membrane.MessageHandler.sendMessage(message);
-		}
+            Membrane.MessageHandler.sendMessage(message);
+        }
 
-		private void OnTransformChanged(Membrane.Engine_OnTransformChanged message) {
-			if(EntityId == message.entity) {
-				foreach(ComponentViewModel comp in Components) {
-					if(comp.GetType() == typeof(TransformComponentViewModel)) {
-						var transform = (TransformComponentViewModel)comp;
-						transform.Update(message.position, message.rotation, message.scale);
-						break;
-					}
-				}
-			}
-		}
-	}
+        private void OnTransformChanged(Membrane.Engine_OnTransformChanged message) {
+            if (EntityId == message.entity) {
+                foreach (ComponentViewModel comp in Components) {
+                    if (comp.GetType() == typeof(TransformComponentViewModel)) {
+                        var transform = (TransformComponentViewModel)comp;
+                        transform.Update(message.position, message.rotation, message.scale);
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/bulb/source/EntityViewModel.cs
+++ b/bulb/source/EntityViewModel.cs
@@ -83,6 +83,8 @@ namespace Garlic.Bulb {
                 break;
                 case Membrane.ComponentType.CollisionShape: {
                     var collisionShapeComp = new CollisionShapeComponentViewModel($"{type}", type);
+                    collisionShapeComp.OnSphereShapeChanged = UpdateSphereShape;
+                    collisionShapeComp.OnCubeShapeChanged = UpdateCubeShape;
 
                     componentVm = collisionShapeComp;
                 }
@@ -109,6 +111,22 @@ namespace Garlic.Bulb {
             var message = new Membrane.Editor_UpdateRigidBody();
             message.entity = EntityId;
             message.mass = mass;
+
+            Membrane.MessageHandler.sendMessage(message);
+        }
+
+        private void UpdateSphereShape(float radius) {
+            var message = new Membrane.Editor_UpdateSphereShape();
+            message.entity = EntityId;
+            message.radius = radius;
+
+            Membrane.MessageHandler.sendMessage(message);
+        }
+
+        private void UpdateCubeShape(Membrane.Vector3 halfExtents) {
+            var message = new Membrane.Editor_UpdateCubeShape();
+            message.entity = EntityId;
+            message.halfExtents = halfExtents;
 
             Membrane.MessageHandler.sendMessage(message);
         }

--- a/bulb/source/EntityViewModel.cs
+++ b/bulb/source/EntityViewModel.cs
@@ -38,6 +38,8 @@ namespace Garlic.Bulb {
             Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnComponentCreated>(OnComponentCreated);
             Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnRigidBodyChanged>(OnRigidBodyChanged);
             Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnTransformChanged>(OnTransformChanged);
+            Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnSphereShapeChanged>(OnSphereShapeChanged);
+            Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnCubeShapeChanged>(OnCubeShapeChanged);
 
             //Set up commands
             SelectedCommand = new RelayCommand(() => OnSelected?.Invoke(this));
@@ -149,6 +151,31 @@ namespace Garlic.Bulb {
                     if (comp.GetType() == typeof(TransformComponentViewModel)) {
                         var transform = (TransformComponentViewModel)comp;
                         transform.Update(message.position, message.rotation, message.scale);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private void OnSphereShapeChanged(Membrane.Engine_OnSphereShapeChanged message) {
+            if (EntityId == message.entity) {
+                foreach (ComponentViewModel comp in Components) {
+                    if (comp.GetType() == typeof(CollisionShapeComponentViewModel)) {
+                        var collisionShape = (CollisionShapeComponentViewModel)comp;
+                        collisionShape.UpdateSphereShape(message.radius);
+                        break;
+                    }
+                }
+            }
+
+        }
+
+        private void OnCubeShapeChanged(Membrane.Engine_OnCubeShapeChanged message) {
+            if (EntityId == message.entity) {
+                foreach(ComponentViewModel comp in Components) {
+                    if (comp.GetType() == typeof(CollisionShapeComponentViewModel)) {
+                        var collisionShape = (CollisionShapeComponentViewModel)comp;
+                        collisionShape.UpdateCubeShape(message.halfExtents);
                         break;
                     }
                 }

--- a/bulb/source/EntityViewModel.cs
+++ b/bulb/source/EntityViewModel.cs
@@ -81,6 +81,12 @@ namespace Garlic.Bulb {
                     componentVm = rigidBodyComp;
                 }
                 break;
+                case Membrane.ComponentType.CollisionShape: {
+                    var collisionShapeComp = new CollisionShapeComponentViewModel($"{type}", type);
+
+                    componentVm = collisionShapeComp;
+                }
+                break;
                 default:
                     componentVm = new ComponentViewModel($"{type}", type);
                     break;

--- a/bulb/source/MainWindow.xaml
+++ b/bulb/source/MainWindow.xaml
@@ -79,9 +79,14 @@
 					</ListBox.Resources>
 				</ListBox>
 				<Menu HorizontalAlignment="Center">
-					<MenuItem Header="Add Component">
-						<MenuItem Header="Transform Component" Command="{Binding Scene.AddComponentCommand}" CommandParameter="{x:Static membrane:ComponentType.Transform}"/>
-						<MenuItem Header="Mesh Component" Command="{Binding Scene.AddComponentCommand}" CommandParameter="{x:Static membrane:ComponentType.Mesh}"/>
+					<MenuItem Header="Add Component" ItemsSource="{Binding Scene.ComponentMenuItems}">
+						<!--Doing a regular DataTemplate here will cause a MenuItem within a MenuItem. So manually set up the container style ourselves-->
+						<MenuItem.ItemContainerStyle>
+							<Style TargetType="MenuItem">
+								<Setter Property="Header" Value="{Binding ComponentType}"/>
+								<Setter Property="Command" Value="{Binding OnSelectedCommand}"/>
+							</Style>
+						</MenuItem.ItemContainerStyle>
 					</MenuItem>
 				</Menu>
 			</StackPanel>

--- a/bulb/source/MainWindow.xaml
+++ b/bulb/source/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Garlic.Bulb"
+		xmlns:membrane="clr-namespace:garlic.membrane;assembly=BulbMembrane"
         mc:Ignorable="d"
         Title="MainWindow" Width="1280" Height="720"
 		MouseMove="Window_MouseMove">
@@ -79,8 +80,8 @@
 				</ListBox>
 				<Menu HorizontalAlignment="Center">
 					<MenuItem Header="Add Component">
-						<MenuItem Header="Transform Component" Command="{Binding Scene.AddTransformComponentCommand}"/>
-						<MenuItem Header="Mesh Component" Command="{Binding Scene.AddMeshComponentCommand}"/>
+						<MenuItem Header="Transform Component" Command="{Binding Scene.AddComponentCommand}" CommandParameter="{x:Static membrane:ComponentType.Transform}"/>
+						<MenuItem Header="Mesh Component" Command="{Binding Scene.AddComponentCommand}" CommandParameter="{x:Static membrane:ComponentType.Mesh}"/>
 					</MenuItem>
 				</Menu>
 			</StackPanel>

--- a/bulb/source/MainWindow.xaml
+++ b/bulb/source/MainWindow.xaml
@@ -90,6 +90,28 @@
 							</StackPanel>
 						</DataTemplate>
 
+						<DataTemplate DataType="{x:Type local:CollisionShapeComponentViewModel}">
+							<StackPanel>
+								<TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+								<Menu HorizontalAlignment="Left">
+									<MenuItem Header="{Binding CurrentShapeType}" ItemsSource="{Binding AvailableShapes}">
+										<!--Doing a regular DataTemplate here will cause a MenuItem within a MenuItem. So manually set up the container style ourselves-->
+										<MenuItem.ItemContainerStyle>
+											<Style TargetType="MenuItem">
+												<Setter Property="Header" Value="{Binding Name}"/>
+												<Setter Property="Command" Value="{Binding OnSelectedCommand}"/>
+											</Style>
+										</MenuItem.ItemContainerStyle>
+									</MenuItem>
+								</Menu>
+								<StackPanel Orientation="Horizontal" Visibility="{Binding RadiusVisibility}">
+									<TextBlock Text="Radius"/>
+									<TextBox Text="0"/>
+								</StackPanel>
+								<local:Vector3Box Visibility="{Binding HalfExtentsVisibility}" Label="Half Extents" LeftFieldText="X" LeftFieldValue="0" CenterFieldText="Y" CenterFieldValue="0" RightFieldText="Z" RightFieldValue="0"/>
+							</StackPanel>
+						</DataTemplate>
+
 						<DataTemplate DataType="{x:Type local:ComponentViewModel}">
 							<TextBlock Text="{Binding Name}" FontWeight="Bold"/>
 						</DataTemplate>

--- a/bulb/source/MainWindow.xaml
+++ b/bulb/source/MainWindow.xaml
@@ -73,6 +73,21 @@
 							</StackPanel>
 						</DataTemplate>
 
+						<DataTemplate DataType="{x:Type local:RigidBodyComponentViewModel}">
+							<StackPanel>
+								<TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+								<Grid Grid.Column="0" Margin="3,0">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*"/>
+										<ColumnDefinition Width="*"/>
+									</Grid.ColumnDefinitions>
+
+									<TextBlock Grid.Column="0" Text="Mass"/>
+									<TextBox Grid.Column="1" Text="{Binding Mass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+								</Grid>
+							</StackPanel>
+						</DataTemplate>
+
 						<DataTemplate DataType="{x:Type local:ComponentViewModel}">
 							<TextBlock Text="{Binding Name}" FontWeight="Bold"/>
 						</DataTemplate>

--- a/bulb/source/MainWindow.xaml
+++ b/bulb/source/MainWindow.xaml
@@ -106,9 +106,9 @@
 								</Menu>
 								<StackPanel Orientation="Horizontal" Visibility="{Binding RadiusVisibility}">
 									<TextBlock Text="Radius"/>
-									<TextBox Text="0"/>
+									<TextBox Text="{Binding Radius, Mode=TwoWay}"/>
 								</StackPanel>
-								<local:Vector3Box Visibility="{Binding HalfExtentsVisibility}" Label="Half Extents" LeftFieldText="X" LeftFieldValue="0" CenterFieldText="Y" CenterFieldValue="0" RightFieldText="Z" RightFieldValue="0"/>
+								<local:Vector3Box Visibility="{Binding HalfExtentsVisibility}" Label="Half Extents" LeftFieldText="X" LeftFieldValue="{Binding HalfExtentsX, Mode=TwoWay}" CenterFieldText="Y" CenterFieldValue="{Binding HalfExtentsY, Mode=TwoWay}" RightFieldText="Z" RightFieldValue="{Binding HalfExtentsZ, Mode=TwoWay}"/>
 							</StackPanel>
 						</DataTemplate>
 

--- a/bulb/source/MainWindow.xaml
+++ b/bulb/source/MainWindow.xaml
@@ -12,6 +12,8 @@
 		<StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
 			<Button Content="Load" Command="{Binding LoadSceneCommand}"/>
 			<Button Content="Save" Command="{Binding SaveSceneCommand}"/>
+			<Button Content="Play" Command="{Binding PlayCommand}" IsEnabled="{Binding IsPlayButtonEnabled}"/>
+			<Button Content="Stop" Command="{Binding StopCommand}" IsEnabled="{Binding IsStopButtonEnabled}"/>
 		</StackPanel>
 		<Grid DockPanel.Dock="Bottom">
 			<Grid.ColumnDefinitions>

--- a/bulb/source/RelayCommand.cs
+++ b/bulb/source/RelayCommand.cs
@@ -18,4 +18,20 @@ namespace Garlic.Bulb
 
         public void Execute(object parameter) => action();
     }
+
+    /// <summary>
+    /// Simple RelayCommand that invokes and action with a single parameter when executed
+    /// </summary>
+    /// <typeparam name="ParameterType"></typeparam>
+    public class RelayCommand<ParameterType> : ICommand {
+        public event EventHandler CanExecuteChanged = (sender, e) => { };
+
+        private Action<ParameterType> action;
+
+        public RelayCommand(Action<ParameterType> action) => this.action = action;
+
+        public bool CanExecute(object parameter) => true;
+
+        public void Execute(object parameter) => action((ParameterType)parameter);
+    }
 }

--- a/bulb/source/RigidBodyComponentViewModel.cs
+++ b/bulb/source/RigidBodyComponentViewModel.cs
@@ -1,0 +1,27 @@
+using Membrane = garlic.membrane;
+
+namespace Garlic.Bulb {
+    public class RigidBodyComponentViewModel : ComponentViewModel {
+        public string Mass {
+            get { return mass.ToString(); }
+            set {
+                float number;
+                float.TryParse(value, out number);
+                OnRigidBodyChanged?.Invoke(number);
+            }
+        }
+
+        private float mass = 1.0f;//TEMP: Initialise to 1 - should init to what the data is
+
+        public delegate void RigdBodyChangedHandler(float mass);
+        public RigdBodyChangedHandler OnRigidBodyChanged;
+
+        public RigidBodyComponentViewModel(string name, Membrane.ComponentType type) : base(name, type) { }
+
+        public void Update(float mass) {
+            this.mass = mass;
+
+            OnPropertyChanged(nameof(Mass));
+        }
+    }
+}

--- a/bulb/source/SceneViewModel.cs
+++ b/bulb/source/SceneViewModel.cs
@@ -5,6 +5,8 @@ using System.Windows.Input;
 using System.Windows;
 
 using Membrane = garlic.membrane;
+using System;
+using System.Linq;
 
 namespace Garlic.Bulb {
 	/// <summary>
@@ -15,6 +17,7 @@ namespace Garlic.Bulb {
 		public ICommand AddComponentCommand { get; }
 
 		public ObservableCollection<EntityViewModel> Entities { get; } = new ObservableCollection<EntityViewModel>();
+		public ObservableCollection<ComponentMenuItemViewModel> ComponentMenuItems { get; } = new ObservableCollection<ComponentMenuItemViewModel>();
 
 		public EntityViewModel SelectedEntity {
 			get { return selectedEntity; }
@@ -35,13 +38,14 @@ namespace Garlic.Bulb {
 		public SceneViewModel() {
 			//Bind to messages
 			Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnEntityCreated>(OnEntityCreated);
+			Membrane.MessageHandler.bindToMessage<Membrane.Engine_OnComponentCreated>(OnComponentCreated);
 
 			//Set up commands
 			CreateEntityCommand = new RelayCommand(() => Membrane.MessageHandler.sendMessage(new Membrane.Editor_CreateEntity()));
 			AddComponentCommand = new RelayCommand<Membrane.ComponentType>(CreateComponent);
 		}
 
-		public SceneViewModel(List<Membrane.Entity> entities) : this() {
+        public SceneViewModel(List<Membrane.Entity> entities) : this() {
 			//TODO: Move to function
 			foreach (var entity in entities){
 				var entityVm = new EntityViewModel(entity.components);
@@ -57,17 +61,48 @@ namespace Garlic.Bulb {
 			var entityVm = new EntityViewModel();
 			entityVm.EntityId = message.entity;
 			entityVm.Name = message.name;
-			entityVm.OnSelected = (EntityViewModel viewModel) => SelectedEntity = viewModel;
+			entityVm.OnSelected = SelectEntity;
 
 			Entities.Add(entityVm);
 		}
 
+		private void OnComponentCreated(Membrane.Engine_OnComponentCreated message) {
+			//Remove the created component from the selected entity's menu item list
+			if (message.entity == SelectedEntity.EntityId) {
+				foreach (var menuItem in ComponentMenuItems) {
+					if(menuItem.ComponentType == message.componentType) {
+						ComponentMenuItems.Remove(menuItem);
+						return;
+                    }
+                }
+            }
+		}
+
+		private void SelectEntity(EntityViewModel entity) {
+			SelectedEntity = entity;
+			UpdateAvailableComponents(SelectedEntity);
+        }
+
 		private void CreateComponent(Membrane.ComponentType componentType) {
 			if(SelectedEntity != null) {
 				SelectedEntity.AddComponent(componentType);
-            } else {
+			} else {
 				Membrane.Log.write(Membrane.LogLevel.Warning, $"CreateComponent called with unkown type: {componentType}");
             }
         }
-	};
-}
+
+		private void UpdateAvailableComponents(EntityViewModel entity) {
+			List<Membrane.ComponentType> entitiesComponents = new List<Membrane.ComponentType>();
+			foreach (ComponentViewModel component in entity.Components) {
+				entitiesComponents.Add(component.Type);
+			}
+
+			//Get a list of components the entity does not have
+			IEnumerable<Membrane.ComponentType> missingComponents = Enum.GetValues(typeof(Membrane.ComponentType)).Cast<Membrane.ComponentType>().Except(entitiesComponents);
+
+			ComponentMenuItems.Clear();
+			foreach (Membrane.ComponentType componentType in missingComponents) {
+				ComponentMenuItems.Add(new ComponentMenuItemViewModel(componentType, new RelayCommand(() => CreateComponent(componentType))));
+			}
+		}
+	}}

--- a/bulb/source/SceneViewModel.cs
+++ b/bulb/source/SceneViewModel.cs
@@ -51,7 +51,7 @@ namespace Garlic.Bulb {
 				var entityVm = new EntityViewModel(entity.components);
 				entityVm.EntityId = entity.id;
 				entityVm.Name = entity.name;
-				entityVm.OnSelected = (EntityViewModel viewModel) => SelectedEntity = viewModel;
+				entityVm.OnSelected = SelectEntity;
 
 				Entities.Add(entityVm);
 			}

--- a/bulb/source/SceneViewModel.cs
+++ b/bulb/source/SceneViewModel.cs
@@ -68,7 +68,7 @@ namespace Garlic.Bulb {
 
 		private void OnComponentCreated(Membrane.Engine_OnComponentCreated message) {
 			//Remove the created component from the selected entity's menu item list
-			if (message.entity == SelectedEntity.EntityId) {
+			if (SelectedEntity != null && message.entity == SelectedEntity.EntityId) {
 				foreach (var menuItem in ComponentMenuItems) {
 					if(menuItem.ComponentType == message.componentType) {
 						ComponentMenuItems.Remove(menuItem);

--- a/bulb/source/SceneViewModel.cs
+++ b/bulb/source/SceneViewModel.cs
@@ -12,8 +12,7 @@ namespace Garlic.Bulb {
 	/// </summary>
 	public class SceneViewModel : ViewModel {
 		public ICommand CreateEntityCommand { get; }
-		public ICommand AddTransformComponentCommand { get; }
-		public ICommand AddMeshComponentCommand { get; }
+		public ICommand AddComponentCommand { get; }
 
 		public ObservableCollection<EntityViewModel> Entities { get; } = new ObservableCollection<EntityViewModel>();
 
@@ -39,8 +38,7 @@ namespace Garlic.Bulb {
 
 			//Set up commands
 			CreateEntityCommand = new RelayCommand(() => Membrane.MessageHandler.sendMessage(new Membrane.Editor_CreateEntity()));
-			AddTransformComponentCommand = new RelayCommand(() => SelectedEntity?.AddComponent(Membrane.ComponentType.Transform));
-			AddMeshComponentCommand = new RelayCommand(() => SelectedEntity?.AddComponent(Membrane.ComponentType.Mesh));
+			AddComponentCommand = new RelayCommand<Membrane.ComponentType>(CreateComponent);
 		}
 
 		public SceneViewModel(List<Membrane.Entity> entities) : this() {
@@ -63,5 +61,13 @@ namespace Garlic.Bulb {
 
 			Entities.Add(entityVm);
 		}
+
+		private void CreateComponent(Membrane.ComponentType componentType) {
+			if(SelectedEntity != null) {
+				SelectedEntity.AddComponent(componentType);
+            } else {
+				Membrane.Log.write(Membrane.LogLevel.Warning, $"CreateComponent called with unkown type: {componentType}");
+            }
+        }
 	};
 }

--- a/bulb/source/TransformComponentViewModel.cs
+++ b/bulb/source/TransformComponentViewModel.cs
@@ -110,6 +110,8 @@ namespace Garlic.Bulb
         public delegate void TransformChangedHandler(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale);
         public TransformChangedHandler OnTransformChanged;
 
+        public TransformComponentViewModel(string name, Membrane.ComponentType type) : base(name, type) { }
+
         public void Update(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale){
             this.position = position;
             this.rotation = rotation;

--- a/clove/CMakeLists.txt
+++ b/clove/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(
 		${INCLUDE}/Components/ParentComponent.hpp
 		${INCLUDE}/Components/PointLightComponent.hpp
 		${INCLUDE}/Components/RigidBodyComponent.hpp
+		${SOURCE}/Components/RigidBodyComponent.cpp
 		${INCLUDE}/Components/StaticModelComponent.hpp
 		${INCLUDE}/Components/TransformComponent.hpp
 		${SOURCE}/Components/TransformComponent.cpp

--- a/clove/components/systems/serialisation/source/Node.cpp
+++ b/clove/components/systems/serialisation/source/Node.cpp
@@ -74,8 +74,5 @@ namespace garlic::clove::serialiser {
 
     Node::Node(std::string_view key)
         : scalar{ key } {
-        Node child{};
-        child.type = Type::Scalar;
-        nodes.emplace_back(std::move(child));
     }
 }

--- a/clove/components/systems/serialisation/tests/NodeTests.cpp
+++ b/clove/components/systems/serialisation/tests/NodeTests.cpp
@@ -150,3 +150,24 @@ TEST(NodeTests, CanPushBackOntoAMapNode) {
 
     EXPECT_EQ(root["Map"].getType(), Node::Type::Map);
 }
+
+TEST(NodeTests, WontIterateEmptyNode) {
+    bool loopedEmpty{ false };
+
+    Node empty{};
+    for(auto &node : empty){
+        loopedEmpty = true;
+        break;
+    }
+
+    EXPECT_FALSE(loopedEmpty);
+
+    bool loopedEmptyChild{ false };
+
+    for(auto &node : empty["child"]) {
+        loopedEmptyChild = true;
+        break;
+    }
+
+    EXPECT_FALSE(loopedEmptyChild);
+}

--- a/clove/include/Clove/Application.hpp
+++ b/clove/include/Clove/Application.hpp
@@ -114,7 +114,7 @@ namespace garlic::clove {
         //Systems
         inline ForwardRenderer3D *getRenderer() const;
         inline EntityManager *getEntityManager();
-        inline PhysicsLayer *getPhysicsLayer() const;
+        inline std::shared_ptr<PhysicsLayer> getPhysicsLayer() const;
 
     private:
         Application(std::unique_ptr<GhaDevice> graphicsDevice, std::unique_ptr<AhaDevice> audioDevice, std::unique_ptr<Surface> surface, std::unique_ptr<RenderTarget> renderTarget);

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -23,7 +23,7 @@ namespace garlic::clove {
         return &entityManager;
     }
 
-    PhysicsLayer *Application::getPhysicsLayer() const {
-        return physicsLayer.get();
+   std::shared_ptr<PhysicsLayer> Application::getPhysicsLayer() const {
+        return physicsLayer;
     }
 }

--- a/clove/include/Clove/Components/CollisionShapeComponent.hpp
+++ b/clove/include/Clove/Components/CollisionShapeComponent.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Clove/SerialisationCommon.hpp"
+
 #include <Clove/Maths/Vector.hpp>
 #include <variant>
 
@@ -22,6 +24,43 @@ namespace garlic::clove {
         };
         using ShapeVariant = std::variant<Sphere, Cube>;
 
-        ShapeVariant shape{Sphere{}}; //Provide a constructed shape to work around a problem on g++/clang 10
+        ShapeVariant shape{ Sphere{} };//Provide a constructed shape to work around a problem on g++/clang 10
     };
+}
+
+namespace garlic::clove {
+    enum class ShapeSeralisationType : uint32_t {
+        Sphere = 0,
+        Cube   = 1,
+    };
+
+    template<>
+    inline serialiser::Node serialise(CollisionShapeComponent const &object) {
+        serialiser::Node node{};
+        if(auto *sphere{ std::get_if<CollisionShapeComponent::Sphere>(&object.shape) }) {
+            node["type"]  = ShapeSeralisationType::Sphere;
+            node["value"] = sphere->radius;
+        } else if(auto *cube{ std::get_if<CollisionShapeComponent::Cube>(&object.shape) }) {
+            node["type"]  = ShapeSeralisationType::Cube;
+            node["value"] = cube->halfExtents;
+        }
+        return node;
+    }
+
+    template<>
+    inline CollisionShapeComponent deserialise(serialiser::Node const &node) {
+        CollisionShapeComponent component{};
+        auto shapeType{ node["type"].as<ShapeSeralisationType>() };
+        switch(shapeType) {
+            case ShapeSeralisationType::Sphere:
+                component.shape = CollisionShapeComponent::Sphere{ node["value"].as<float>() };
+                break;
+            case ShapeSeralisationType::Cube:
+                component.shape = CollisionShapeComponent::Cube{ node["value"].as<vec3f>() };
+                break;
+            default:
+                break;
+        }
+        return component;
+    }
 }

--- a/clove/include/Clove/Components/CollisionShapeComponent.hpp
+++ b/clove/include/Clove/Components/CollisionShapeComponent.hpp
@@ -38,10 +38,10 @@ namespace garlic::clove {
     inline serialiser::Node serialise(CollisionShapeComponent const &object) {
         serialiser::Node node{};
         if(auto *sphere{ std::get_if<CollisionShapeComponent::Sphere>(&object.shape) }) {
-            node["type"]  = ShapeSeralisationType::Sphere;
+            node["type"]  = static_cast<uint32_t>(ShapeSeralisationType::Sphere);
             node["value"] = sphere->radius;
         } else if(auto *cube{ std::get_if<CollisionShapeComponent::Cube>(&object.shape) }) {
-            node["type"]  = ShapeSeralisationType::Cube;
+            node["type"]  = static_cast<uint32_t>(ShapeSeralisationType::Cube);
             node["value"] = cube->halfExtents;
         }
         return node;
@@ -50,7 +50,7 @@ namespace garlic::clove {
     template<>
     inline CollisionShapeComponent deserialise(serialiser::Node const &node) {
         CollisionShapeComponent component{};
-        auto shapeType{ node["type"].as<ShapeSeralisationType>() };
+        ShapeSeralisationType const shapeType{ node["type"].as<uint32_t>() };
         switch(shapeType) {
             case ShapeSeralisationType::Sphere:
                 component.shape = CollisionShapeComponent::Sphere{ node["value"].as<float>() };

--- a/clove/include/Clove/Components/RigidBodyComponent.hpp
+++ b/clove/include/Clove/Components/RigidBodyComponent.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Clove/SerialisationCommon.hpp"
+
 #include <Clove/Maths/Vector.hpp>
 #include <cinttypes>
 #include <optional>
@@ -53,14 +55,14 @@ namespace garlic::clove {
         /**
          * @brief Sets a consistent velocity for the body to move in.
          */
-        void setLinearVelocity(vec3f velocity){
+        void setLinearVelocity(vec3f velocity) {
             appliedVelocity = velocity;
         }
 
         /**
          * @brief Returns the current velocity of the body
          */
-        vec3f getLinearVelocity(){
+        vec3f getLinearVelocity() const {
             return currentVelocity;
         }
 
@@ -86,4 +88,30 @@ namespace garlic::clove {
 
         vec3f currentVelocity{};
     };
+}
+
+namespace garlic::clove {
+    template<>
+    inline serialiser::Node serialise(RigidBodyComponent const &object) {
+        serialiser::Node node{};
+        node["collisionGroup"] = object.collisionGroup;
+        node["collisionMask"]  = object.collisionMask;
+        node["mass"]           = object.mass;
+        node["restitution"]    = object.restitution;
+        node["angularFactor"]  = object.angularFactor;
+        node["linearFactor"]   = object.linearFactor;
+        return node;
+    }
+
+    template<>
+    inline RigidBodyComponent deserialise(serialiser::Node const &node) {
+        RigidBodyComponent component{};
+        component.collisionGroup = node["collisionGroup"].as<uint32_t>();
+        component.collisionMask  = node["collisionMask"].as<uint32_t>();
+        component.mass           = node["mass"].as<float>();
+        component.restitution    = node["restitution"].as<float>();
+        component.angularFactor  = node["angularFactor"].as<vec3f>();
+        component.linearFactor   = node["linearFactor"].as<vec3f>();
+        return component;
+    }
 }

--- a/clove/include/Clove/Components/RigidBodyComponent.hpp
+++ b/clove/include/Clove/Components/RigidBodyComponent.hpp
@@ -36,8 +36,6 @@ namespace garlic::clove {
          */
         float mass{ 1.0f };
 
-        
-
         /**
          * @brief The bouncyness of this body. Anything higher than 0 will cause the body to increase in bouncyness.
          */
@@ -71,18 +69,14 @@ namespace garlic::clove {
          * @param force The direction + power of the force.
          * @param relativeOffset The offset in relation to the body's center of mass.
          */
-        void applyForce(vec3f force, vec3f relativeOffset = { 0.0f, 0.0f, 0.0f }){
-            appliedForce = ForceApplication{ .amount = std::move(force), .offset = std::move(relativeOffset) };
-        }
+        void applyForce(vec3f force, vec3f relativeOffset = { 0.0f, 0.0f, 0.0f });
 
         /**
          * @brief Apply a 1 frame burst of force to this body.
          * @param impulse The direction + power of the impulse.
          * @param relativeOffset The offset in relation to the body's center of mass.
          */
-        void applyImpulse(vec3f impulse, vec3f relativeOffset = { 0.0f, 0.0f, 0.0f }){
-            appliedImpulse = ForceApplication{ .amount = std::move(impulse), .offset = std::move(relativeOffset) };
-        }
+        void applyImpulse(vec3f impulse, vec3f relativeOffset = { 0.0f, 0.0f, 0.0f });
 
     private:
         std::optional<vec3f> appliedVelocity{};

--- a/clove/source/Components/RigidBodyComponent.cpp
+++ b/clove/source/Components/RigidBodyComponent.cpp
@@ -2,10 +2,10 @@
 
 namespace garlic::clove{
     void RigidBodyComponent::applyForce(vec3f force, vec3f relativeOffset) {
-        appliedForce = ForceApplication{ .amount = std::move(force), .offset = std::move(relativeOffset) };
+        appliedForce = ForceApplication{ .amount = force, .offset = relativeOffset };
     }
 
     void RigidBodyComponent::applyImpulse(vec3f impulse, vec3f relativeOffset) {
-        appliedImpulse = ForceApplication{ .amount = std::move(impulse), .offset = std::move(relativeOffset) };
+        appliedImpulse = ForceApplication{ .amount = impulse, .offset = relativeOffset };
     }
 }

--- a/clove/source/Components/RigidBodyComponent.cpp
+++ b/clove/source/Components/RigidBodyComponent.cpp
@@ -1,0 +1,11 @@
+#include "Clove/Components/RigidBodyComponent.hpp"
+
+namespace garlic::clove{
+    void RigidBodyComponent::applyForce(vec3f force, vec3f relativeOffset) {
+        appliedForce = ForceApplication{ .amount = std::move(force), .offset = std::move(relativeOffset) };
+    }
+
+    void RigidBodyComponent::applyImpulse(vec3f impulse, vec3f relativeOffset) {
+        appliedImpulse = ForceApplication{ .amount = std::move(impulse), .offset = std::move(relativeOffset) };
+    }
+}

--- a/clove/source/Layers/PhysicsLayer.cpp
+++ b/clove/source/Layers/PhysicsLayer.cpp
@@ -109,8 +109,7 @@ namespace garlic::clove {
             if(!entityManager->hasComponent<CollisionShapeComponent>(entity) || !entityManager->hasComponent<RigidBodyComponent>(entity)) {
                 proxiesToRemove.push_back(entity);
             }
-        },
-                               Exclude<ShapeOnlyComponent, BodyOnlyComponent>{});
+        }, Exclude<ShapeOnlyComponent, BodyOnlyComponent>{});
 
         //Remove them outside of the loops their found in.
         for(auto entity : proxiesToRemove) {

--- a/clove/source/Layers/PhysicsLayer.cpp
+++ b/clove/source/Layers/PhysicsLayer.cpp
@@ -172,11 +172,16 @@ namespace garlic::clove {
         entityManager->forEach([&](TransformComponent const &transform, PhysicsProxyComponent const &proxy) {
             auto const &pos{ transform.position };
             auto const &rot{ transform.rotation };
+            auto const &scale{ transform.scale };
 
-            btTransform btTrans = proxy.collisionObject->getWorldTransform();
+            btTransform btTrans{ proxy.collisionObject->getWorldTransform() };
             btTrans.setOrigin({ pos.x, pos.y, pos.z });
             btTrans.setRotation({ rot.x, rot.y, rot.z, rot.w });
             proxy.collisionObject->setWorldTransform(btTrans);
+
+            if(proxy.collisionShape != nullptr) {
+                proxy.collisionShape->setLocalScaling(btVector3{ scale.x, scale.y, scale.z });
+            }
         });
 
         //Step physics world


### PR DESCRIPTION
## Summary

Adds functionality to the editor to have two states. 'Editor time' and 'Game time'. Editor time is when the user will add scripts / create entities / modify objects etc. Game time is when the editor simulates the running game

Closes #277 

## Changes
- AddComponents in Bulb is now completely data driven.
- Added the rigid body and collision shape components to bulb.
- Added serialisation for `RigidBodyComponent`.
- Added serialisation for `CollisionShapeComponent`.
- Modified RuntimeLayer and EditorLayer to better reflect the two states Bulb can be in.
- Stopped a crash when a component is added without a selected entity
- Fixed a bug that would cause empty nodes to crash when iterated over in a const constext
- TransformComponent scale now gets applied to a rigid body's collision shape
- Added 'play' and 'stop' buttons in the editor to switch between runtime and editor time.