### PR TITLE
Fixed crashes that could happen when resizing the viewport

### DIFF
--- a/bulb/source/EditorApp.xaml.cs
+++ b/bulb/source/EditorApp.xaml.cs
@@ -60,16 +60,20 @@ namespace Garlic.Bulb {
                     //Send any editor events to the engine
                     Membrane.MessageHandler.flushEditor();
 
-                    //Update the application
-                    engineApp.tick();
+                    lock (editorWindow.EditorViewport.ResizeMutex) {
+                        //Resize before rendering
+                        if (size != editorWindow.EditorViewport.Size) {
+                            size = editorWindow.EditorViewport.Size;
 
-                    //Render to image
-                    if (size != editorWindow.EditorViewport.Size) {
-                        size = editorWindow.EditorViewport.Size;
+                            engineApp.resize((int)size.Width, (int)size.Height);
+                        }
 
-                        engineApp.resize((int)size.Width, (int)size.Height);
+                        //Update the application
+                        engineApp.tick();
+
+                        //Render to image
+                        editorWindow.EditorViewport.WriteToBackBuffer(engineApp.render);
                     }
-                    editorWindow.EditorViewport.WriteToBackBuffer(engineApp.render);
 
                     //Send any engine events to the editor
                     Membrane.MessageHandler.flushEngine(Current.Dispatcher);

--- a/bulb/source/Views/Viewport.xaml.cs
+++ b/bulb/source/Views/Viewport.xaml.cs
@@ -38,6 +38,12 @@ namespace Garlic.Bulb {
 
         private void UpdateBackBufferSize(Size size) {
             lock (ResizeMutex) {
+                if(size.Width < 1) {
+                    size.Width = 1;
+                }
+                if(size.Height < 1) {
+                    size.Height = 1;
+                }
                 Size = size;
 
                 imageSource = new WriteableBitmap((int)size.Width, (int)size.Height, 96, 96, PixelFormats.Pbgra32, null);

--- a/bulb/source/Views/Viewport.xaml.cs
+++ b/bulb/source/Views/Viewport.xaml.cs
@@ -9,6 +9,8 @@ namespace Garlic.Bulb {
     public partial class Viewport : UserControl {
         public delegate void RenderDelegate(IntPtr backBuffer);
 
+        public object ResizeMutex { get; } = new object();
+
         public Size Size { get; private set; }
 
         private WriteableBitmap imageSource;
@@ -35,12 +37,14 @@ namespace Garlic.Bulb {
         private void OnSizeChanged(object sender, SizeChangedEventArgs e) => UpdateBackBufferSize(e.NewSize);
 
         private void UpdateBackBufferSize(Size size) {
-            Size = size;
+            lock (ResizeMutex) {
+                Size = size;
 
-            imageSource = new WriteableBitmap((int)size.Width, (int)size.Height, 96, 96, PixelFormats.Pbgra32, null);
+                imageSource = new WriteableBitmap((int)size.Width, (int)size.Height, 96, 96, PixelFormats.Pbgra32, null);
 
-            Image.Source = imageSource;
-            backBuffer = imageSource.BackBuffer;
+                Image.Source = imageSource;
+                backBuffer = imageSource.BackBuffer;
+            }
         }
     }
 }

--- a/clove/include/Clove/Rendering/GraphicsImageRenderTarget.hpp
+++ b/clove/include/Clove/Rendering/GraphicsImageRenderTarget.hpp
@@ -39,6 +39,8 @@ namespace garlic::clove {
         std::shared_ptr<GhaImageView> renderTargetView;
         std::shared_ptr<GhaBuffer> renderTargetBuffer;
 
+        bool requiresResize{ false };
+
         //FUNCTIONS
     public:
         GraphicsImageRenderTarget() = delete;


### PR DESCRIPTION
## Summary

## Changes
- Added resize mutex on the viewpoint for when size changes
- Added better resize image flow to `GraphicsImageRenderTarget`
- Prevented the viewport being resized below 0