### PR TITLE
AnimatedModel's move assignment correctly calls StaticModel's one

### DIFF
--- a/clove/source/Rendering/Renderables/AnimatedModel.cpp
+++ b/clove/source/Rendering/Renderables/AnimatedModel.cpp
@@ -57,7 +57,7 @@ namespace garlic::clove {
     }
 
     AnimatedModel &AnimatedModel::operator=(AnimatedModel &&other) noexcept {
-        StaticModel::operator=(other);
+        StaticModel::operator=(std::move(other));
         animator             = std::move(other.animator);
         skeleton             = std::move(other.skeleton);
         animClips            = std::move(other.animClips);


### PR DESCRIPTION
## Summary
This fixes a cast failed bug in some circumstances
