### PR TITLE
Minor renderer refactors

### DIFF
--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
@@ -28,6 +28,9 @@ namespace garlic::clove {
 
         /**
          * @brief Submit command buffers to be processed.
+         * @details All buffers in a single submission will start in order but will likely finish out of order.
+         * Batch them together like this if they can run at the same time. Each call to this submit function
+         * will need to wait on previous submissions.
          * @param signalFence An optional fence that will be signaled when all submissions are complete.
          */
         virtual void submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence const *signalFence) = 0;

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
@@ -28,6 +28,9 @@ namespace garlic::clove {
 
         /**
          * @brief Submit command buffers to be processed.
+         * @details All buffers in a single submission will start in order but will likely finish out of order.
+         * Batch them together like this if they can run at the same time. Each call to this submit function
+         * will need to wait on previous submissions.
          * @param signalFence An optional fence that will be signaled when all submissions are complete.
          */
         virtual void submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence const *signalFence) = 0;

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
@@ -30,6 +30,9 @@ namespace garlic::clove {
 
         /**
          * @brief Submit command buffers to be processed.
+         * @details All buffers in a single submission will start in order but will likely finish out of order.
+         * Batch them together like this if they can run at the same time. Each call to this submit function
+         * will need to wait on previous submissions.
          * @param signalFence An optional fence that will be signaled when all submissions are complete.
          */
         virtual void submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence const *signalFence) = 0;

--- a/clove/include/Clove/Rendering/ForwardRenderer3D.hpp
+++ b/clove/include/Clove/Rendering/ForwardRenderer3D.hpp
@@ -150,8 +150,6 @@ namespace garlic::clove {
         std::shared_ptr<GhaRenderPass> shadowMapRenderPass;
 
         //Synchronisation obects
-        std::array<std::shared_ptr<GhaSemaphore>, maxFramesInFlight> shadowFinishedSemaphores;
-        std::array<std::shared_ptr<GhaSemaphore>, maxFramesInFlight> cubeShadowFinishedSemaphores;
         std::array<std::shared_ptr<GhaSemaphore>, maxFramesInFlight> skinningFinishedSemaphores;
 
         //TEMP: Compute skinning objects -- Put inside a GeometryPass

--- a/clove/source/Rendering/ForwardRenderer3D.cpp
+++ b/clove/source/Rendering/ForwardRenderer3D.cpp
@@ -64,12 +64,6 @@ namespace garlic::clove {
         createRenderTargetResources();
 
         //Create semaphores for frame synchronisation
-        for(auto &shadowFinishedSemaphore : shadowFinishedSemaphores) {
-            shadowFinishedSemaphore = *ghaFactory->createSemaphore();
-        }
-        for(auto &cubeShadowFinishedSemaphore : cubeShadowFinishedSemaphores) {
-            cubeShadowFinishedSemaphore = *ghaFactory->createSemaphore();
-        }
         for(auto &skinningFinishedSemaphore : skinningFinishedSemaphores) {
             skinningFinishedSemaphore = *ghaFactory->createSemaphore();
         }
@@ -399,8 +393,7 @@ namespace garlic::clove {
         //Submit the command buffers for the shadow maps.
         GraphicsSubmitInfo cubeShadowSubmitInfo{
             .waitSemaphores   = { { skinningFinishedSemaphores[currentFrame], PipelineStage::VertexShader } },
-            .commandBuffers   = { currentImageData.shadowMapCommandBuffer, currentImageData.cubeShadowMapCommandBuffer },
-            .signalSemaphores = { shadowFinishedSemaphores[currentFrame], cubeShadowFinishedSemaphores[currentFrame] },
+            .commandBuffers   = { currentImageData.shadowMapCommandBuffer, currentImageData.cubeShadowMapCommandBuffer }
         };
         graphicsQueue->submit({ std::move(cubeShadowSubmitInfo) }, nullptr);
 
@@ -481,10 +474,6 @@ namespace garlic::clove {
 
         //Submit the colour output to the render target
         GraphicsSubmitInfo submitInfo{
-            .waitSemaphores = {
-                { shadowFinishedSemaphores[currentFrame], PipelineStage::PixelShader },
-                { cubeShadowFinishedSemaphores[currentFrame], PipelineStage::PixelShader },
-            },
             .commandBuffers = { currentImageData.commandBuffer },
         };
         renderTarget->submit(imageIndex, currentFrame, std::move(submitInfo));


### PR DESCRIPTION
## Summary
Refactoring the renderer to simplify it a little bit.

## Changes
- Both shadow passes are batched together
- Removed the single submission that waits on the skinning pass and moved that into the shadow submission
- Updated the documentation on the GHA queues
